### PR TITLE
PsTEE fixes

### DIFF
--- a/eefixpack/files/tph/pst_are_fixes.tph
+++ b/eefixpack/files/tph/pst_are_fixes.tph
@@ -1,0 +1,59 @@
+// fixing area flags
+COPY_EXISTING ~ar0402.are~ ~override~
+  // clear bit 1 (Reform Party not allowed)
+  // set bit 4 (Player1 can die), bit 7 ("You cannot rest here.")
+  WRITE_LONG 0x14 (THIS BAND BNOT BIT1
+                        BOR BIT4
+                        BOR BIT7)
+BUT_ONLY
+
+// fixing offsets
+COPY_EXISTING ~ar0501.are~ ~override~
+  SET bytes = (LONG_AT 0xac) * 76 // # bytes of animation block
+  WRITE_LONG 0xbc (THIS + bytes)  // songs offset
+BUT_ONLY
+
+// fixing offsets
+COPY_EXISTING ~ar1001.are~ ~override~
+              ~ar3017.are~ ~override~
+  READ_LONG 0xb0 anim_off
+  SET bytes = (LONG_AT 0xac) * 76 // # bytes of animation block
+  
+    // offsets: tiled objects, songs, rest encounters, automap notes, projectile traps
+  PATCH_FOR_EACH off IN 0xb8 0xbc 0xc0 0xc4 0xcc BEGIN
+    PATCH_IF (LONG_AT off >= anim_off) BEGIN
+      WRITE_LONG off (THIS + bytes)
+    END
+  END
+BUT_ONLY
+
+// removing bogus data
+COPY_EXISTING ~ar13wz.are~ ~override~
+  READ_LONG 0xac anim_num
+  PATCH_IF (anim_num = 6 AND SOURCE_SIZE = 4016) BEGIN  // sanity check
+    // removing duplicate block of 6 animation entries
+    READ_LONG 0xb0 anim_off
+    SET bytes = 6 * 76  // # bytes of animation block
+    DELETE_BYTES (anim_off + bytes) bytes
+
+    // clearing bogus animation flags
+    FOR (i = 0; i < anim_num; ++i) BEGIN
+      SET off = anim_off + (i * 76)
+      WRITE_LONG (off + 0x34) (THIS BAND BNOT (BIT13 + BIT16))
+    END
+  END
+BUT_ONLY
+
+// making Pillar of Skulls shadow animation visible
+COPY_EXISTING ~ar1001.are~ ~override~
+              ~ar3017.are~ ~override~
+  READ_LONG 0xac anim_num
+  READ_LONG 0xb0 anim_off
+  FOR (i = 0; i < anim_num; ++i) BEGIN
+    SET off = anim_off + (i * 76)
+    READ_ASCII (off + 0x28) resref (8) NULL // animation resref
+    PATCH_IF (~%resref%~ STR_EQ ~POSSHAD~) BEGIN
+      WRITE_LONG (off + 0x34) (THIS BAND BNOT BIT8) // animation flags
+    END
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/pst_bam_fixes.tph
+++ b/eefixpack/files/tph/pst_bam_fixes.tph
@@ -1,0 +1,39 @@
+// Wrapper function to patch uncompressed BAM data
+DEFINE_PATCH_FUNCTION a7_process_bam_data
+STR_VAR
+  // Name of function to call for processing uncompressed BAM data.
+  function = ~~
+BEGIN
+  READ_ASCII 0x0 sig (8)
+  SET is_bamc = ~%sig%~ STR_EQ ~BAMCV1  ~
+
+  PATCH_IF (is_bamc) BEGIN
+    READ_LONG 0x8 unc_size  // uncompressed size
+    DECOMPRESS_REPLACE_FILE 0xc (SOURCE_SIZE - 0xc) unc_size
+  END
+
+  PATCH_IF (NOT ~%function%~ STR_EQ ~~) BEGIN
+    LPF ~%function%~ END
+  END
+
+  PATCH_IF (is_bamc) BEGIN
+    COMPRESS_REPLACE_FILE 0 unc_size 6
+    INSERT_BYTES 0x0 0xc
+    WRITE_ASCII 0x0 ~BAMCV1  ~ (8)
+    WRITE_LONG 0x8 unc_size
+  END
+
+END
+
+// Patches alpha of palette entry 1
+DEFINE_PATCH_FUNCTION a7_bam_patch_pos_shadow
+BEGIN
+  READ_LONG 0x10 ofs_palette
+  WRITE_BYTE (ofs_palette + 4 + 3) 192
+END
+
+
+// semi-transparent Pillar of Skulls shadow
+COPY_EXISTING ~posshad.bam~ ~override~
+  LPF a7_process_bam_data STR_VAR function = ~a7_bam_patch_pos_shadow~ END
+BUT_ONLY

--- a/eefixpack/files/tph/pst_wed_fixes.tph
+++ b/eefixpack/files/tph/pst_wed_fixes.tph
@@ -1,0 +1,91 @@
+// This function updates WED file offsets by the specified amount
+DEFINE_PATCH_FUNCTION a7_update_wed_offsets
+INT_VAR
+  // Offset to the resource field which contains the value to be compared to file offsets.
+  // Base offset and offsets less (or equal) to the base_offset value are excluded from the update.
+  base_offset = 0
+  // Number of bytes to add to matching offsets. Can be a positive or negative value.
+  amount      = 0
+BEGIN
+  PATCH_IF (amount != 0) BEGIN
+    READ_LONG base_offset base_value
+
+    // updating overlay offsets
+    READ_LONG 0x8 overlays_num
+    READ_LONG 0x10 overlays_off
+    FOR (i = 0; i < overlays_num; ++i) BEGIN    // scanning overlay entries
+      SET off = overlays_off + (i * 24)
+      PATCH_FOR_EACH rel_off IN 0x10 0x14 BEGIN // tilemap and index lookup offsets
+        SET cur_off = off + rel_off
+        PATCH_IF (cur_off != base_offset) BEGIN // exclude base offset
+          READ_LONG cur_off value
+          PATCH_IF ((value > base_value) OR
+                    ((value = base_value) AND (cur_off > base_offset))) BEGIN
+            WRITE_LONG cur_off (THIS + amount)
+          END
+        END
+      END
+    END
+
+    // updating secondary header offsets
+    READ_LONG 0x14 header_off
+    PATCH_FOR_EACH rel_off IN 0x4 0x8 0xc 0x10 BEGIN  // polygons, vertices, wallgroups and lookup offsets
+      SET cur_off = header_off + rel_off
+      PATCH_IF (cur_off != base_offset) BEGIN         // exclude base offset
+        READ_LONG cur_off value
+        PATCH_IF ((value > base_value) OR
+                  ((value = base_value) AND (cur_off > base_offset))) BEGIN
+          WRITE_LONG cur_off (THIS + amount)
+        END
+      END
+    END
+
+    // updating absolute offsets
+    PATCH_FOR_EACH cur_off IN 0x10 0x14 0x18 0x1c BEGIN // overlays, 2nd header, doors and door tile offsets
+      PATCH_IF (cur_off != base_offset) BEGIN           // exclude base offset
+        READ_LONG cur_off value
+        PATCH_IF ((value > base_value) OR
+                  ((value = base_value) AND (cur_off > base_offset))) BEGIN
+          WRITE_LONG cur_off (THIS + amount)
+        END
+      END
+    END
+  END
+END
+
+
+// removing bogus data
+COPY_EXISTING ~ar0609.wed~ ~override~
+              ~ar0612.wed~ ~override~
+  PATCH_IF (LONG_AT 0x1c = 0x14ac) BEGIN  // sanity check
+    READ_LONG 0x10 overlays_off
+    // only first overlay structure is relevant
+    READ_LONG (overlays_off + 0x10) tiles_off
+    READ_LONG (overlays_off + 0x14) lookup_off
+
+    // number of overlay tile definitions
+    SET tiles_num = (SHORT_AT (overlays_off)) * (SHORT_AT (overlays_off + 2))
+
+    // number of bogus entries is calculated from the gap between end of tilemap entries and tile index lookup offset
+    // Note: door tilemap lookup offset should be considered as well if door definitions exist
+    SET bogus_num = ((lookup_off - tiles_off) / 10) - tiles_num
+
+    // fixing bogus tile index lookup entries
+    SET amount = bogus_num * 2
+    DELETE_BYTES (lookup_off + tiles_num * 2) amount
+    LPF a7_update_wed_offsets
+      INT_VAR
+        base_offset = overlays_off + 0x14
+        amount      = 0 - amount
+    END
+
+    // fixing bogus tilemap entries
+    SET amount = bogus_num * 10
+    DELETE_BYTES (tiles_off + tiles_num * 10) amount
+    LPF a7_update_wed_offsets
+      INT_VAR
+        base_offset = overlays_off + 0x10
+        amount      = 0 - amount
+    END
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/pstee.tph
+++ b/eefixpack/files/tph/pstee.tph
@@ -1,5 +1,3 @@
-// fixes for pstee; rename without underscore when we have our first fix
-
 /////                                                  \\\\\
 ///// string fixes                                     \\\\\
 /////                                                  \\\\\
@@ -32,9 +30,19 @@ COMPILE ~eefixpack/files/d/%game%_core_fixes.d~ // misc dialogue fixes
 ///// area fixes                                       \\\\\
 /////                                                  \\\\\
 
+INCLUDE ~eefixpack/files/tph/pst_are_fixes.tph~ // ARE-specific fixes
+INCLUDE ~eefixpack/files/tph/pst_wed_fixes.tph~ // WED-specific fixes
+
 /////                                                  \\\\\
 ///// creature file fixes                              \\\\\
 /////                                                  \\\\\
+
+COPY_EXISTING ~apprent2.cre~ ~override~
+              ~apprent3.cre~ ~override~
+              ~apprent4.cre~ ~override~
+              ~apprent5.cre~ ~override~
+  WRITE_ASCII DEATHVAR ~None~ (32)
+BUT_ONLY
 
 /////                                                  \\\\\
 ///// item file fixes                                  \\\\\
@@ -51,6 +59,11 @@ COMPILE ~eefixpack/files/d/%game%_core_fixes.d~ // misc dialogue fixes
 /////                                                  \\\\\
 ///// misc/other fixes                                 \\\\\
 /////                                                  \\\\\
+
+// removing reference to invalid game file
+DISABLE_FROM_KEY ~.bcs~
+
+INCLUDE ~eefixpack/files/tph/pst_bam_fixes.tph~ // BAM-specific fixes
 
 /////                                                  \\\\\
 ///// final batch of INCLUDEs and cross-patching       \\\\\

--- a/eefixpack/languages/en_us/fixes_pstee.tra
+++ b/eefixpack/languages/en_us/fixes_pstee.tra
@@ -2,5 +2,5 @@
 // the corresponding string in the tlk. Remember to comment why a string is being updated. Once you have legitimate
 // strings to replace, rename this file WITHOUT the underscore at the beginning. 
 
-// strref #12345, updating because "X is misspelled"
-@12345 = ~This is a test replacement string.~
+// fixes invalid store item trigger
+@51352 = ~Global("Trias_DEAD_KAPUTZ", "GLOBAL", 1)~


### PR DESCRIPTION
PsTEE fixes:
- Fixed incorrect script names (apprent2.cre, ..., apprent5.cre)
- Removed reference to .bcs resource (file with empty resref) which may provoke WeiDU installations to fail
- Fixed item sale trigger in Fell's store
- Fixed incorrect header data in ar0501.are, ar1001.are, ar3017.are
- Fixed duplicate animation entries in ar13wz.are
- Fixed Pillar of Skulls shadow (animation entry in ar1001.are and ar3017.are; transparency in posshad.bam)
- Fixed area flags in ar0402.are (clears "Reform party not allowed" flag; sets default area flags)
- Fixed bogus data in wed files (ar0609.wed, ar0612.wed)