### PR TITLE
Misc fixes and tweaks

### DIFF
--- a/eefixpack/files/lib/cd_functions.tpa
+++ b/eefixpack/files/lib/cd_functions.tpa
@@ -528,3 +528,58 @@ BEGIN
   END
 
 END
+
+// found by Ardanis in Rogue Rebalancing, had apparently been written by Nythrun
+// fixed two things, wrapped a function over it
+
+DEFINE_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ BEGIN
+
+  PATCH_IF !(~%SOURCE_FILE%~ STRING_MATCHES_REGEXP ~^.+\.spl~) BEGIN
+    hs = 0x28
+    WRITE_LONG 0xc ~-1~ //Identified name
+    WRITE_LONG 0x54 ~-1~ //Identified description
+    PATCH_FOR_EACH tz IN 0x44 0x48 0x58 0x5c BEGIN
+      WRITE_LONG tz 0
+    END
+  END ELSE PATCH_IF !(~%SOURCE_FILE%~ STRING_MATCHES_REGEXP ~^.+\.itm~) BEGIN
+    hs = 0x38
+  END
+  READ_LONG 0x64 hf //Extended header offset
+  READ_SHORT 0x68 hc //Extended header count
+  READ_LONG 0x6a fb //Feature block table offset
+  READ_SHORT 0x70 fc //Feature block count
+  PATCH_IF ((hf > fb) AND (hc > 0)) BEGIN // Ardanis: fixed "hc > 1" to "hc > 0"
+    READ_ASCII hf ~eh~ ELSE ~fail~ (hs * hc)
+    PATCH_IF (~%eh%~ STRING_EQUAL ~fail~) BEGIN
+      WHILE ((~%eh%~ STRING_EQUAL ~fail~) AND (hc > 0)) BEGIN
+        READ_ASCII hf ~eh~ ELSE ~fail~ (hs * hc)
+        hc -= 1
+      END
+    END
+    DELETE_BYTES hf (hs * hc)
+    hf = 0x72
+    WRITE_LONG 0x64 hf
+    WRITE_SHORT 0x68 hc
+    fb = (0x72 + (hs * hc))
+    WRITE_LONG 0x6a fb
+    PATCH_IF !(~%eh%~ STRING_EQUAL ~fail~) BEGIN
+      INSERT_BYTES hf (hs * hc)
+      WRITE_ASCIIE hf ~%eh%~
+    END
+  END ELSE PATCH_IF ((hf != 0x72) AND (hc = 0)) BEGIN
+    hf = 0x72
+    WRITE_LONG 0x64 hf
+  END
+  FOR (i1 = 0; i1 < (hs * hc); i1 += hs) BEGIN
+    WRITE_SHORT (hf + i1 + 0x20) fc
+    READ_SHORT (hf + i1 + 0x1e) cx
+    fc += cx
+  END
+  PATCH_IF (SOURCE_SIZE > (0x72 + (hs * hc) + (0x30 * fc))) BEGIN
+    DELETE_BYTES (0x72 + (hs * hc) + (0x30 * fc)) (SOURCE_SIZE - (0x72 + (hs * hc) + (0x30 * fc)))
+  END
+
+  // added by Ardanis
+  WRITE_SHORT 0x6e 0
+
+END // end of function

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -169,6 +169,16 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+
+
+// luke
+// Spirit Fire => should not interact with spell protections
+// As a result, do not use "bddoom.spl" (since its effects are coded as `power=1`)
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/cleric_spirit_fire.tph"
+  LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -179,6 +179,21 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
 END
 
+
+
+// luke
+// Nature's Beauty – permanent blindness (until dispelled)
+// 1) Timing Mode 1 will permanently set the creature's STATE_BLIND flag, leaving no removable effect.
+// 2) Related: the -4 penalty to AC and THAC0 are apparently tied to the effect (op74), not STATE_BLIND.
+// As a result, we suggest to stick with a limited `timing_mode` and set `duration` to a very high random value (max signed value...?).
+// Additionally, this spell should only affect HUMANOID (there are a lot of unnatural creatures that are immune to it via op206; also, it is intended, right...?)
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%CLERIC_NATURE_BEAUTY%.spl~ ~override~
+    LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = 0 "opcode" = 324 "target" = 2 "power" = 7 "parameter2" = 6 "resist_dispel" = BIT1 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (GENERAL != HUMANOID)
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 74 "timing" = 0 "duration" = 0x7FFFFFFF END // Blindness
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -88,9 +88,28 @@ COPY_EXISTING ~ohbgit01.cre~ ~override~
               ~ohrjassa.cre~ ~override~
   REPLACE_CRE_ITEM ~plat23~ #0 #0 #0 ~NONE~ ~ARMOR~ // replace plat19, the special 0-lore armor from wish with identical plate with lore
 
+
+
+// BGCS-469, luke
+// Lizard Men should be flagged as 'LIZARDMAN'
+WITH_SCOPE BEGIN
+  COPY_EXISTING_REGEXP ~ohbliz0[1-3].cre~ ~override~ // The Black Pits 2
+    WRITE_BYTE 0x272 IDS_OF_SYMBOL ("RACE" "LIZARDMAN")
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// item file fixes                                  \\\\\
 /////                                                  \\\\\
+
+// luke
+// Mis-indexed effects
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~hamm06.itm~ ~override~ // Dwarven Thrower +3
+                ~staf01.itm~ ~override~ // Quarterstaff
+    LAUNCH_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ END
+  BUT_ONLY_IF_IT_CHANGES
+END
 
 // tbd, cam
 // fixing paperdoll animations
@@ -118,6 +137,27 @@ END
 COPY_EXISTING ~melstone.spl~ ~override~
   WRITE_BYTE 0x27 7 // change secondary to Combat Protections
   BUT_ONLY
+
+
+
+// luke
+// Mis-indexed effects
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~ohbwi302.spl~ ~override~ // Remove Magic
+                ~ohbwi304.spl~ ~override~ // Fireball
+    LAUNCH_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
+
+
+// luke
+// Mimic Glue should not set the GREASE stat
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%MIMIC_GLUE%.spl~ ~override~ // Mimic Glue
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 158 "opcode" = 215 "parameter2" = 1 STR_VAR "resource" = "GREASED" END // Grease overlay => Play visual effect, Mode: Over target (attached)
+  BUT_ONLY_IF_IT_CHANGES
+END
 
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -111,6 +111,16 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+// luke
+// – Neera's Staff +1 => When the staff strikes a target, there is a 10% chance that either the target or the wielder will take 1 point of fire damage
+//// This isn't implemented properly since the two op12 effects share the same probability range... Also, whilw we're at it, make sure it's 10% chance and not 11% chance...
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~stafn1.itm~ ~override~ // Neera's Staff +1
+    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~check_globals~ = 0 ~multi_match~ = 1 ~match_opcode~ = 12 ~probability1~ = 9 END // 10% chance (target)
+    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~check_globals~ = 0 ~match_opcode~ = 12 ~match_probability1~ = 10 ~probability2~ = 10 ~probability1~ = 19 END // 10% chance (wielder)
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 // tbd, cam
 // fixing paperdoll animations
 ACTION_DEFINE_ASSOCIATIVE_ARRAY cd_paperdoll_animations BEGIN 

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -256,6 +256,18 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+
+
+// luke
+// – Neera's Staff +1 => When the staff strikes a target, there is a 10% chance that either the target or the wielder will take 1 point of fire damage
+//// This isn't implemented properly since the two op12 effects share the same probability range... Also, whilw we're at it, make sure it's 10% chance and not 11% chance...
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~stafn1.itm~ ~override~ // Neera's Staff +1
+    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~check_globals~ = 0 ~multi_match~ = 1 ~match_opcode~ = 12 ~probability1~ = 9 END // 10% chance (target)
+    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~check_globals~ = 0 ~match_opcode~ = 12 ~match_probability1~ = 10 ~probability2~ = 10 ~probability1~ = 19 END // 10% chance (wielder)
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// spell fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -224,7 +224,7 @@ COPY_EXISTING ~bdcrus21.cre~ ~override~
 // CRE files should not use non-existing resources
 WITH_SCOPE BEGIN
   COPY_EXISTING ~bdmcarri.cre~ ~override~ // Mutated Crawler – currently equipped with the non-existing "bdmcarri.itm"
-    REPLACE_CRE_ITEM ~carrio1~ #0 #0 #0 ~none~ ~weapon~ EQUIP // the other mutated crawler file "bdcrawmu.cre" uses "carrio1", so we'll put "carrio1" here as well...
+    REPLACE_CRE_ITEM ~carrio1~ #0 #0 #0 ~unstealable&undroppable~ ~weapon~ EQUIP // the other mutated crawler file "bdcrawmu.cre" uses "carrio1", so we'll put "carrio1" here as well...
   BUT_ONLY IF_EXISTS // sod
 END
 

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -290,6 +290,24 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+
+
+// luke
+// Night Club +1 => THAC0: +2 at night (implemented via op232)
+// 1) Remember that "blun38.spl" will be cast immediately whenever you load, and twice as often with haste, so you cannot avoid an overlapping duration without applying a leading op321 effect.
+// 2) Similarly, remember that Slow will reduce the trigger of op232 to 200 ticks!
+// As a result, we will double the duration of op54. I.e., We will not allow Slow and Haste to impact it (really, it does not make sense in this case)
+// Additionally, sectype should be 0|NONE
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~blun38.spl~ ~override~
+    // Header
+    WRITE_BYTE 0x27 0 // Secondary type: NONE
+    // Feature blocks
+    LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = 0 "opcode" = 321 "target" = 1 "timing" = 1 STR_VAR "resource" = "%DEST_RES%" END // Remove effects by resource
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 54 "duration" = 13 END // Base THAC0 bonus => Some random duration value strictly greater than 200 ticks...
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -318,6 +318,21 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
 END
 
+
+
+// luke
+// Nature's Beauty – permanent blindness (until dispelled)
+// 1) Timing Mode 1 will permanently set the creature's STATE_BLIND flag, leaving no removable effect.
+// 2) Related: the -4 penalty to AC and THAC0 are apparently tied to the effect (op74), not STATE_BLIND.
+// As a result, we suggest to stick with a limited `timing_mode` and set `duration` to a very high random value (max signed value...?).
+// Additionally, this spell should only affect HUMANOID (there are a lot of unnatural creatures that are immune to it via op206; also, it is intended, right...?)
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%CLERIC_NATURE_BEAUTY%.spl~ ~override~
+    LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = 0 "opcode" = 324 "target" = 2 "power" = 7 "parameter2" = 6 "resist_dispel" = BIT1 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (GENERAL != HUMANOID)
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 74 "timing" = 0 "duration" = 0x7FFFFFFF END // Blindness
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -218,13 +218,65 @@ COPY_EXISTING ~bdcrus21.cre~ ~override~
   WRITE_ASCIIE 0x280 ~%SOURCE_RES%~ #32 // was bdcrus20
   BUT_ONLY IF_EXISTS // sod
 
+
+
+// BGCS-483, luke
+// CRE files should not use non-existing resources
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~bdmcarri.cre~ ~override~ // Mutated Crawler – currently equipped with the non-existing "bdmcarri.itm"
+    REPLACE_CRE_ITEM ~carrio1~ #0 #0 #0 ~none~ ~weapon~ EQUIP // the other mutated crawler file "bdcrawmu.cre" uses "carrio1", so we'll put "carrio1" here as well...
+  BUT_ONLY IF_EXISTS // sod
+END
+
+WITH_SCOPE BEGIN
+  // ~mepmag01.cre~ (Magma Mephit) – currently equipped with the non-existing "mepmag.itm"
+  // Since there's no other Magma Mephit file, let us make "mepmag.itm" from scratch (based on BG2:EE)
+  COPY_EXISTING "b1-4.itm" "override/mepmag.itm"
+    // Header
+    WRITE_LONG NAME1 "-1"
+    WRITE_LONG NAME2 "-1"
+    WRITE_LONG UNIDENTIFIED_DESC "-1"
+    WRITE_LONG DESC "-1"
+    // Extended header
+    LPF "ALTER_ITEM_HEADER" INT_VAR "dicenumber" = 1 "dicesize" = 2 "damage_type" = 3 END // 1d2 (slashing)
+    // Feature block
+    LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 1 "opcode" = 12 "target" = 2 "parameter2" = IDS_OF_SYMBOL ("DMGTYPE" "FIRE") "timing" = 1 "dicenumber" = 1 "dicesize" = 8 END // 1d8 (fire)
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// item file fixes                                  \\\\\
 /////                                                  \\\\\
 
+// luke
+// Mis-indexed effects
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~ption41.itm~ ~override~ // Potion of Power
+    LAUNCH_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// spell fixes                                      \\\\\
 /////                                                  \\\\\
+
+// luke
+// Mis-indexed effects
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%ERINYES_CHARM%.spl~ ~override~ // Charm Person
+    LAUNCH_PATCH_FUNCTION ~FJ_SPL_ITM_REINDEX~ END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
+
+
+// luke
+// Mimic Glue should not set the GREASE stat
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%MIMIC_GLUE%.spl~ ~override~ // Mimic Glue
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 158 "opcode" = 215 "parameter2" = 1 STR_VAR "resource" = "GREASED" END // Grease overlay => Play visual effect, Mode: Over target (attached)
+  BUT_ONLY_IF_IT_CHANGES
+END
 
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -308,6 +308,16 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+
+
+// luke
+// Spirit Fire => should not interact with spell protections
+// As a result, do not use "bddoom.spl" (since its effects are coded as `power=1`)
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/cleric_spirit_fire.tph"
+  LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -416,6 +416,29 @@ COPY_EXISTING ~%CLERIC_WALL_OF_MOONLIGHT%a.spl~ ~override~ // sppr428a
 
 
 
+// luke
+// 1) Grease should not interact with spell protections
+// 2) Grease (in particular "spwi101b.spl" and "spwi101c.spl") should apply the GREASE stat.
+///// As you can see, those two subspells are not applying the aforementioned stat, nor the GREASE spell state. This might confuse both later patches and AI.
+///// As a result, I suggest replacing op215 with op158 (param2=1|custom overlay; resource="greaseb" on "spwi101b" and resource="greasec" on "spwi101c").
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%WIZARD_GREASE%b.spl~ ~override~ // spwi101b
+                ~%WIZARD_GREASE%c.spl~ ~override~ // spwi101c
+    LPF ~ALTER_EFFECT~ INT_VAR ~power~ = 0 END
+    LPF ~ALTER_EFFECT~ INT_VAR ~match_opcode~ = 215 ~opcode~ = 158 END // Play visual effect => Grease overlay
+  BUT_ONLY_IF_IT_CHANGES
+END
+
+
+
+// luke
+// Chill Touch should correctly affect UNDEAD without permanently removing their immunity to Panic (op24)
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/wizard_chill_touch.tph"
+  LAF "WIZARD_CHILL_TOUCH" END
+END
+
+
 // ie-5947, cam
 // Cloudburst should remove Fireshields
 COPY_EXISTING ~%CLERIC_CLOUDBURST%.spl~ ~override~ // sppr325

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -550,6 +550,21 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
 END
 
+
+
+// luke
+// Nature's Beauty – permanent blindness (until dispelled)
+// 1) Timing Mode 1 will permanently set the creature's STATE_BLIND flag, leaving no removable effect.
+// 2) Related: the -4 penalty to AC and THAC0 are apparently tied to the effect (op74), not STATE_BLIND.
+// As a result, we suggest to stick with a limited `timing_mode` and set `duration` to a very high random value (max signed value...?).
+// Additionally, this spell should only affect HUMANOID (there are a lot of unnatural creatures that are immune to it via op206; also, it is intended, right...?)
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%CLERIC_NATURE_BEAUTY%.spl~ ~override~
+    LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = 0 "opcode" = 324 "target" = 2 "power" = 7 "parameter2" = 6 "resist_dispel" = BIT1 STR_VAR "resource" = "%DEST_RES%" END // Immunity to resource and message (GENERAL != HUMANOID)
+    LAUNCH_PATCH_FUNCTION "ALTER_EFFECT" INT_VAR "match_opcode" = 74 "timing" = 0 "duration" = 0x7FFFFFFF END // Blindness
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -416,29 +416,6 @@ COPY_EXISTING ~%CLERIC_WALL_OF_MOONLIGHT%a.spl~ ~override~ // sppr428a
 
 
 
-// luke
-// 1) Grease should not interact with spell protections
-// 2) Grease (in particular "spwi101b.spl" and "spwi101c.spl") should apply the GREASE stat.
-///// As you can see, those two subspells are not applying the aforementioned stat, nor the GREASE spell state. This might confuse both later patches and AI.
-///// As a result, I suggest replacing op215 with op158 (param2=1|custom overlay; resource="greaseb" on "spwi101b" and resource="greasec" on "spwi101c").
-WITH_SCOPE BEGIN
-  COPY_EXISTING ~%WIZARD_GREASE%b.spl~ ~override~ // spwi101b
-                ~%WIZARD_GREASE%c.spl~ ~override~ // spwi101c
-    LPF ~ALTER_EFFECT~ INT_VAR ~power~ = 0 END
-    LPF ~ALTER_EFFECT~ INT_VAR ~match_opcode~ = 215 ~opcode~ = 158 END // Play visual effect => Grease overlay
-  BUT_ONLY_IF_IT_CHANGES
-END
-
-
-
-// luke
-// Chill Touch should correctly affect UNDEAD without permanently removing their immunity to Panic (op24)
-WITH_SCOPE BEGIN
-  INCLUDE "eefixpack/files/tph/luke/wizard_chill_touch.tph"
-  LAF "WIZARD_CHILL_TOUCH" END
-END
-
-
 // ie-5947, cam
 // Cloudburst should remove Fireshields
 COPY_EXISTING ~%CLERIC_CLOUDBURST%.spl~ ~override~ // sppr325
@@ -538,6 +515,40 @@ COPY_EXISTING ~%MONK_LAY_ON_HANDS%.spl~          ~override~ // spcl815 lay on ha
     LPF CLONE_EFFECT INT_VAR match_opcode = 324 match_parameter2 = 55 parameter1 = race parameter2 = 104 END 
   END   
   BUT_ONLY
+
+
+
+// luke
+// 1) Grease should not interact with spell protections
+// 2) Grease (in particular "spwi101b.spl" and "spwi101c.spl") should apply the GREASE stat.
+///// As you can see, those two subspells are not applying the aforementioned stat, nor the GREASE spell state. This might confuse both later patches and AI.
+///// As a result, I suggest replacing op215 with op158 (param2=1|custom overlay; resource="greaseb" on "spwi101b" and resource="greasec" on "spwi101c").
+WITH_SCOPE BEGIN
+  COPY_EXISTING ~%WIZARD_GREASE%b.spl~ ~override~ // spwi101b
+                ~%WIZARD_GREASE%c.spl~ ~override~ // spwi101c
+    LPF ~ALTER_EFFECT~ INT_VAR ~power~ = 0 END
+    LPF ~ALTER_EFFECT~ INT_VAR ~match_opcode~ = 215 ~opcode~ = 158 END // Play visual effect => Grease overlay
+  BUT_ONLY_IF_IT_CHANGES
+END
+
+
+
+// luke
+// Chill Touch should correctly affect UNDEAD without permanently removing their immunity to Panic (op24)
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/wizard_chill_touch.tph"
+  LAF "WIZARD_CHILL_TOUCH" END
+END
+
+
+
+// luke
+// Spirit Fire => should not interact with spell protections
+// As a result, do not use "bddoom.spl" (since its effects are coded as `power=1`)
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/cleric_spirit_fire.tph"
+  LAUNCH_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE" END
+END
 
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\

--- a/eefixpack/files/tph/luke/cleric_spirit_fire.tph
+++ b/eefixpack/files/tph/luke/cleric_spirit_fire.tph
@@ -1,0 +1,41 @@
+DEFINE_ACTION_FUNCTION "CLERIC_SPIRIT_FIRE"
+BEGIN
+	// Make a clone of "bddoom.spl" and edit it accordingly
+	WITH_SCOPE BEGIN
+		COPY_EXISTING ~bddoom.spl~ ~override/%CLERIC_SPIRIT_FIRE%a.spl~
+			// Header
+			WRITE_SHORT 0x1C 2 // Spell type: Priest (as the main SPL file)
+			// Feature blocks
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"power" = 0
+			END
+			LPF "ALTER_EFFECT"
+			STR_VAR
+				"match_resource" = "%SOURCE_RES%" // old resref
+				"resource" = "%DEST_RES%" // new resref
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// Main SPL
+	WITH_SCOPE BEGIN
+		COPY_EXISTING ~%CLERIC_SPIRIT_FIRE%.spl~ ~override~
+			// Feature blocks
+			LPF "ALTER_EFFECT"
+			STR_VAR
+				"match_resource" = "bddoom" // old resref
+				"resource" = "%DEST_RES%a" // new resref
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// Spirits, fey creatures, elementals, and spectral undead take double damage
+	WITH_SCOPE BEGIN
+		COPY_EXISTING ~%CLERIC_SPIRIT_FIRE%b.spl~ ~override~
+			// Feature blocks
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"power" = 0
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END

--- a/eefixpack/files/tph/luke/wizard_chill_touch.tph
+++ b/eefixpack/files/tph/luke/wizard_chill_touch.tph
@@ -1,0 +1,77 @@
+DEFINE_ACTION_FUNCTION "WIZARD_CHILL_TOUCH"
+BEGIN
+	////////////////////////////////////////////////////////////////////
+	//// Magically created weapon
+	////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "CTOUCH.ITM" "override"
+			// op337 always acts as permanent – As a result, do not apply it, otherwise you'll permanently remove Panic immunity from Undead (and that would be incorrect)
+			LPF "DELETE_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+			STR_VAR
+				"match_resource" = "%WIZARD_CHILL_TOUCH%C"
+			END
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+				"timing" = 1 // Permanent until death
+				"duration" = 0
+				//"resist_dispel" = 2 // Remember that the Magic Resistance field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Magic Resistance on op326, to avoid unnecessary feedback.
+				//"savingthrow" = 0 // Remember that the Saving Throw field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Saving Throws on op326, to avoid unnecessary feedback.
+			STR_VAR
+				"match_resource" = "%WIZARD_CHILL_TOUCH%A"
+			END
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 326 // Apply effects list
+				"timing" = 1 // Permanent until death
+				"duration" = 0
+				//"resist_dispel" = 2 // Remember that the Magic Resistance field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Magic Resistance on op326, to avoid unnecessary feedback.
+				//"savingthrow" = 0 // Remember that the Saving Throw field is checked BEFORE the splprot/IDS filter, so it's usually better to not have Saving Throws on op326, to avoid unnecessary feedback.
+			STR_VAR
+				"match_resource" = "%WIZARD_CHILL_TOUCH%B"
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	////////////////////////////////////////////////////////////////////
+	//// Subspell affecting GENERAL = UNDEAD
+	////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "%WIZARD_CHILL_TOUCH%a.spl" "override"
+			/*LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"resist_dispel" = 1 // Dispel/Not bypass MR
+				"savingthrow" = BIT0 // Save vs. Spell
+			END*/
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"match_opcode" = 24 // Panic
+				"parameter2" = 1 // Panic type => Bypass op101
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	////////////////////////////////////////////////////////////////////
+	//// Subspell affecting GENERAL != UNDEAD
+	////////////////////////////////////////////////////////////////////
+
+	/*WITH_SCOPE BEGIN
+		COPY_EXISTING "%WIZARD_CHILL_TOUCH%b.spl" "override"
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"check_globals" = 0
+				"resist_dispel" = 1 // Dispel/Not bypass MR
+				"savingthrow" = BIT0 // Save vs. Spell
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END*/
+END

--- a/eefixpack/setup-eefixpack.tp2
+++ b/eefixpack/setup-eefixpack.tp2
@@ -1,7 +1,7 @@
 BACKUP ~weidu_external/eefixpack/backup~ // location to store files for uninstall
 SUPPORT ~https://www.gibberlings3.net/forums/forum/232-ee-fixpack/~ // URL displayed if install fails
 AUTO_EVAL_STRINGS
-MODDER missing_eval fail fun_args fail
+MODDER fun_args fail
 
 ALWAYS
 

--- a/eefixpack/setup-eefixpack.tp2
+++ b/eefixpack/setup-eefixpack.tp2
@@ -1,6 +1,7 @@
 BACKUP ~weidu_external/eefixpack/backup~ // location to store files for uninstall
 SUPPORT ~https://www.gibberlings3.net/forums/forum/232-ee-fixpack/~ // URL displayed if install fails
 AUTO_EVAL_STRINGS
+MODDER missing_eval fail fun_args fail
 
 ALWAYS
 


### PR DESCRIPTION
- [BG:EE, BG2:EE] **Neera's Staff +1**
  - Fixed probability values
- [BG:EE, BG2:EE] **Night Club +1**
  - `op232` vs. Haste / Slow
- [IWD:EE] **Grease, Chill Touch**
  - `power` level fixes
   - made sure Grease sets the GREASE stat
   - removed pathological `op337` effect from Chill Touch
- [BG:EE, BG2:EE] **Mimic Glue**
  - It should not set the `GREASE` stat.
- [BG:EE, BG2:EE] Fixed a bunch of **mis-indexed effects**
- [BG:EE] Added missing `mepmag.itm`, made sure `bdmcarri.cre` is equipped with a proper (existing!) natural weapon
- [BG2:EE] Made sure **Lizard Men** are flagged as `LIZARDMAN`
- [BG:EE, BG2:EE, IWD:EE] **Spirit Fire**
  - `power` level fixes
- [BG:EE, BG2:EE, IWD:EE] **Nature's Beauty**
  - `op74` workaround. See the [IESDP](https://gibberlings3.github.io/iesdp/opcodes/bgee.htm#op74) for further details.