### PR TITLE
PsT fixes: item, cre race, combat script, dialog fixes

### DIFF
--- a/eefixpack/files/baf/pst/0900gnr1.baf
+++ b/eefixpack/files/baf/pst/0900gnr1.baf
@@ -1,0 +1,104 @@
+IF
+  OnCreation()
+  !Race(Myself,CAMPATUSKANELLA)
+THEN
+  RESPONSE #100
+    SetGlobal("Attack_Mode","LOCALS",1)
+    Continue()
+END
+
+IF
+  Die()
+  GlobalGT("Curst_Murder","GLOBAL",14)
+THEN
+  RESPONSE #100
+    SetGlobal("Curst_Force_Spawn","GLOBAL",1)
+    Continue()
+END
+
+IF
+  Die()
+  GlobalLT("Curst_Murder","GLOBAL",15)
+THEN
+  RESPONSE #100
+    IncrementGlobal("Curst_Murder","GLOBAL",1)
+    Continue()
+END
+
+IF
+  OnCreation()
+THEN
+  RESPONSE #100
+    SetGlobal("Curst_Spawn","GLOBAL",0)
+    Enemy()
+    Continue()
+END
+
+IF
+  See([PC])
+  !TimerActive(1)
+  Global("Attack_Mode","LOCALS",0)
+THEN
+  RESPONSE #25
+    Enemy()
+    Attack([PC])
+  RESPONSE #75
+    StartTimer(1,10)
+END
+
+IF
+  See([PC])
+  !TimerActive(1)
+  !Global("Attack_Mode","LOCALS",0)
+THEN
+  RESPONSE #25
+    Enemy()
+    RunningAttack([PC])
+  RESPONSE #75
+    StartTimer(1,10)
+END
+
+IF
+  True()
+THEN
+  RESPONSE #100
+    MoveToPoint([3304.1408])
+  RESPONSE #100
+    MoveToPoint([1244.634])
+  RESPONSE #100
+    MoveToPoint([1055.681])
+  RESPONSE #100
+    MoveToPoint([1389.514])
+  RESPONSE #100
+    MoveToPoint([1290.1071])
+  RESPONSE #100
+    MoveToPoint([892.1979])
+  RESPONSE #100
+    MoveToPoint([1173.2082])
+  RESPONSE #100
+    MoveToPoint([1412.2180])
+  RESPONSE #100
+    MoveToPoint([2198.1585])
+  RESPONSE #100
+    MoveToPoint([1686.1627])
+  RESPONSE #100
+    MoveToPoint([2020.1513])
+  RESPONSE #100
+    MoveToPoint([1518.2669])
+  RESPONSE #100
+    MoveToPoint([1763.2577])
+  RESPONSE #100
+    MoveToPoint([2391.2026])
+  RESPONSE #100
+    MoveToPoint([2635.2232])
+  RESPONSE #100
+    MoveToPoint([2899.2165])
+  RESPONSE #100
+    MoveToPoint([2858.2444])
+  RESPONSE #100
+    MoveToPoint([3508.3302])
+  RESPONSE #100
+    MoveToPoint([3742.3340])
+  RESPONSE #100
+    MoveToPoint([3575.2811])
+END

--- a/eefixpack/files/baf/pst/0900gnr2.baf
+++ b/eefixpack/files/baf/pst/0900gnr2.baf
@@ -1,0 +1,104 @@
+IF
+  OnCreation()
+  !Race(Myself,CAMPATUSKANELLA)
+THEN
+  RESPONSE #100
+    SetGlobal("Attack_Mode","LOCALS",1)
+    Continue()
+END
+
+IF
+  Die()
+  GlobalGT("Curst_Murder","GLOBAL",14)
+THEN
+  RESPONSE #100
+    SetGlobal("Curst_Force_Spawn","GLOBAL",1)
+    Continue()
+END
+
+IF
+  Die()
+  GlobalLT("Curst_Murder","GLOBAL",15)
+THEN
+  RESPONSE #100
+    IncrementGlobal("Curst_Murder","GLOBAL",1)
+    Continue()
+END
+
+IF
+  OnCreation()
+THEN
+  RESPONSE #100
+    SetGlobal("Curst_Force_Spawn","GLOBAL",0)
+    Enemy()
+    Continue()
+END
+
+IF
+  See([PC])
+  !TimerActive(1)
+  Global("Attack_Mode","LOCALS",0)
+THEN
+  RESPONSE #25
+    Enemy()
+    Attack([PC])
+  RESPONSE #75
+    StartTimer(1,10)
+END
+
+IF
+  See([PC])
+  !TimerActive(1)
+  !Global("Attack_Mode","LOCALS",0)
+THEN
+  RESPONSE #25
+    Enemy()
+    RunningAttack([PC])
+  RESPONSE #75
+    StartTimer(1,10)
+END
+
+IF
+  True()
+THEN
+  RESPONSE #100
+    MoveToPoint([3304.1408])
+  RESPONSE #100
+    MoveToPoint([1244.634])
+  RESPONSE #100
+    MoveToPoint([1055.681])
+  RESPONSE #100
+    MoveToPoint([1389.514])
+  RESPONSE #100
+    MoveToPoint([1290.1071])
+  RESPONSE #100
+    MoveToPoint([892.1979])
+  RESPONSE #100
+    MoveToPoint([1173.2082])
+  RESPONSE #100
+    MoveToPoint([1412.2180])
+  RESPONSE #100
+    MoveToPoint([2198.1585])
+  RESPONSE #100
+    MoveToPoint([1686.1627])
+  RESPONSE #100
+    MoveToPoint([2020.1513])
+  RESPONSE #100
+    MoveToPoint([1518.2669])
+  RESPONSE #100
+    MoveToPoint([1763.2577])
+  RESPONSE #100
+    MoveToPoint([2391.2026])
+  RESPONSE #100
+    MoveToPoint([2635.2232])
+  RESPONSE #100
+    MoveToPoint([2899.2165])
+  RESPONSE #100
+    MoveToPoint([2858.2444])
+  RESPONSE #100
+    MoveToPoint([3508.3302])
+  RESPONSE #100
+    MoveToPoint([3742.3340])
+  RESPONSE #100
+    MoveToPoint([3575.2811])
+END

--- a/eefixpack/files/baf/pst/2000cati.baf
+++ b/eefixpack/files/baf/pst/2000cati.baf
@@ -1,7 +1,7 @@
 IF
   OnCreation()
-  !Race(Myself,LEMURE)
-  !Race(Myself,NUPPERIBO)
+  !Race(Myself,CAMPATUSKANELLA)
+  !Race(Myself,WORM)
 THEN
   RESPONSE #100
     SetGlobal("Attack_Mode","LOCALS",1)
@@ -16,14 +16,13 @@ THEN
     SavePlace()
 END
 
-// Removed: Caused almost all creatures to disappear again immediately after spawning
-// IF
-//   Global("Destroy_Fiends","AR1000",1)
-//   !Range([PC],30)
-// THEN
-//   RESPONSE #100
-//     DestroySelf()
-// END
+IF
+  Global("Destroy_Cattys","AR2000",1)
+  !Range([PC],30)
+THEN
+  RESPONSE #100
+    DestroySelf()
+END
 
 IF
   See([PC])
@@ -86,7 +85,7 @@ THEN
 END
 
 IF
-  !NearSavedLocationPST(10)
+  !NearSavedLocationPST(5)
 THEN
   RESPONSE #100
     ReturnToSavedPlace()

--- a/eefixpack/files/d/pstee_core_fixes.d
+++ b/eefixpack/files/d/pstee_core_fixes.d
@@ -1,0 +1,17 @@
+// Monster Jug in Vrischika's Curiosity Shop should cost 123 coppers when it is bought
+REPLACE_TRANS_TRIGGER DVRISCH BEGIN 34 END BEGIN 0 END ~PartyGoldGT(99)~ ~PartyGoldGT(122)~
+REPLACE_TRANS_ACTION  DVRISCH BEGIN 34 END BEGIN 0 END ~DestroyPartyGold(100)~ ~DestroyPartyGold(123)~
+
+// Kitla's dialog should not create duplicate journal entries
+ALTER_TRANS DKITLA BEGIN 5 9 END BEGIN 0 END BEGIN "JOURNAL" "#49473" END
+ALTER_TRANS DKITLA BEGIN 9 END BEGIN 1 END BEGIN "JOURNAL" "" END  // remove journal entry
+
+// Fall-from-Grace's dialog should not create duplicate journal entries
+ALTER_TRANS DGRACE BEGIN 72 73 213 214 END BEGIN 0 1 2 END BEGIN "JOURNAL" "#27465" END
+
+// Fall-from-Grace's dialog should show correct reply string (strref 28454 -> 28448)
+ALTER_TRANS DGRACE BEGIN 96 END BEGIN 2 END BEGIN "REPLY" "#28448" END
+
+// Pillar of Skulls dialog should not create duplicate journal entries
+// Note: Choosing string where "Trias the Betrayer" is enclosed in single quotes.
+ALTER_TRANS DPILLAR BEGIN 35 36 END BEGIN 3 END BEGIN "JOURNAL" "#53500" END

--- a/eefixpack/files/tph/pst_script_fixes.tph
+++ b/eefixpack/files/tph/pst_script_fixes.tph
@@ -14,7 +14,7 @@ COPY_EXISTING ~0000bxd2.bcs~ ~override~
               ~0209skel.bcs~ ~override~
               ~0209skld.bcs~ ~override~
               ~0402tegr.bcs~ ~override~
-              ~0403blnd.bcs~ ~override~
+              // ~0403blnd.bcs~ ~override~  // Tiresias (Blind Thug): should not run
               ~0403drnk.bcs~ ~override~
               ~0403gang.bcs~ ~override~
               ~0403gdul.bcs~ ~override~
@@ -32,7 +32,7 @@ COPY_EXISTING ~0000bxd2.bcs~ ~override~
               ~0700atta.bcs~ ~override~
               ~0701atta.bcs~ ~override~
               ~0701hgrd.bcs~ ~override~
-              ~0702cass.bcs~ ~override~
+              // ~0702cass.bcs~ ~override~  // Cassius: Nupperibo appearance, should not run
               ~0702gar2.bcs~ ~override~
               ~0702gar3.bcs~ ~override~
               ~0702gard.bcs~ ~override~
@@ -43,29 +43,29 @@ COPY_EXISTING ~0000bxd2.bcs~ ~override~
               ~0708camp.bcs~ ~override~
               ~0708corn.bcs~ ~override~
               ~0708ghri.bcs~ ~override~
-              ~0708lemu.bcs~ ~override~
-              ~0708nupp.bcs~ ~override~
+              // ~0708lemu.bcs~ ~override~  // Lemure: should not run
+              // ~0708nupp.bcs~ ~override~  // Nupperibo: should not run
               ~0708tre0.bcs~ ~override~
               ~0708tre1.bcs~ ~override~
               ~0708tre2.bcs~ ~override~
               ~0900avng.bcs~ ~override~
-              ~0900ctkr.bcs~ ~override~
-              ~0900gnr1.bcs~ ~override~
-              ~0900gnr2.bcs~ ~override~
+              // ~0900ctkr.bcs~ ~override~  // Dump Caretaker in Curst: Old man, should not run
+              // ~0900gnr1.bcs~ ~override~  // handled elsewhere
+              // ~0900gnr2.bcs~ ~override~  // handled elsewhere
               ~0900grdg.bcs~ ~override~
-              ~0900hrmt.bcs~ ~override~
+              // ~0900hrmt.bcs~ ~override~  // Hermit: should not run
               ~0900hrs1.bcs~ ~override~
               ~0900hrs2.bcs~ ~override~
               ~0900hrs3.bcs~ ~override~
               ~0900jjog.bcs~ ~override~
               ~0900loot.bcs~ ~override~
               ~0900mob.bcs~ ~override~
-              ~0900slv0.bcs~ ~override~
+              // ~0900slv0.bcs~ ~override~  // Thokola: should not run
               ~0900tem1.bcs~ ~override~
               ~0900tem2.bcs~ ~override~
               ~0900tem3.bcs~ ~override~
               ~0900tem4.bcs~ ~override~
-              ~0900tgrd.bcs~ ~override~
+              // ~0900tgrd.bcs~ ~override~  // Thokola: should not run
               ~0900thgb.bcs~ ~override~
               ~0901geh6.bcs~ ~override~
               ~0901gehr.bcs~ ~override~
@@ -84,36 +84,30 @@ COPY_EXISTING ~0000bxd2.bcs~ ~override~
               ~1000corb.bcs~ ~override~
               ~1000corc.bcs~ ~override~
               ~1000cut3.bcs~ ~override~
-              ~1000fnds.bcs~ ~override~
-              ~1000lemd.bcs~ ~override~
+              // ~1000fnds.bcs~ ~override~  // handled elsewhere
+              // ~1000lemd.bcs~ ~override~  // Lemure: should not run
               ~1100anim.bcs~ ~override~
               ~1100grg0.bcs~ ~override~
               ~1100grg4.bcs~ ~override~
-              ~1100grk0.bcs~ ~override~
+              // ~1100grk0.bcs~ ~override~  // Gronk: should not run
               ~1101atta.bcs~ ~override~
               ~1101cut3.bcs~ ~override~
               ~1101cut4.bcs~ ~override~
               ~1101fhju.bcs~ ~override~
-              ~1201sha2.bcs~ ~override~
-              ~1201shad.bcs~ ~override~
+              // ~1201sha2.bcs~ ~override~  // Greater Shadow: should not run
+              // ~1201shad.bcs~ ~override~  // Greater Shadow: should not run
               ~1202vhai.bcs~ ~override~
               ~1203inc.bcs~ ~override~
               ~1203inc1.bcs~ ~override~
               ~1203inc2.bcs~ ~override~
               ~1203inc3.bcs~ ~override~
-              ~1300cons.bcs~ ~override~
-              ~2000cati.bcs~ ~override~
+              // ~1300cons.bcs~ ~override~  // Low/Medium/High Threat Constructs: should not run
+              // ~2000cati.bcs~ ~override~  // handled elsewhere
               ~3015grd1.bcs~ ~override~
               ~3015grd2.bcs~ ~override~
               ~3015sohm.bcs~ ~override~
   DECOMPILE_AND_PATCH BEGIN
-    // preparations
-    TEXT_SPRINT action ~Attack~
-    SET action_len = STRING_LENGTH ~%action%~
-    TEXT_SPRINT new_action ~RunningAttack~
-    SET new_action_len = STRING_LENGTH ~%new_action%~
-
-    // preparing bcs resref for array search
+    // preparing instances for find-and-replace
     TEXT_SPRINT resref ~%SOURCE_RES%~
     TO_LOWER ~resref~
     PATCH_IF (VARIABLE_IS_SET $pst_replace_action(~%resref%~)) BEGIN
@@ -122,24 +116,18 @@ COPY_EXISTING ~0000bxd2.bcs~ ~override~
       TEXT_SPRINT indices ~~
     END
 
-    // replacing actions
+    // Find-and-replace for selected instances: Attack -> RunningAttack
     SET index = 0
-    SET pos = 0
-    WHILE (pos >= 0) BEGIN
-      SET pos = INDEX_BUFFER(CASE_SENSITIVE ~\b%action%(~ pos)
-      PATCH_IF (pos >= 0) BEGIN
-        SET pos2 = INDEX_BUFFER(~(~ pos)
-        PATCH_IF (pos2 > pos) BEGIN
-          PATCH_IF (~%indices%~ STR_EQ ~~ OR
-                    INDEX(~\b%index%\b~ ~%indices%~) >= 0) BEGIN
-            DELETE_BYTES pos (action_len)
-            INSERT_BYTES pos (new_action_len)
-            WRITE_ASCIIE pos ~%new_action%~ (new_action_len)
-          END
+    REPLACE_EVALUATE CASE_SENSITIVE
+      ~\bAttack(~
+      BEGIN
+        PATCH_IF (~%indices%~ STR_EQ ~~ OR INDEX(~\b%index%\b~ ~%indices%~) >= 0) BEGIN
+          TEXT_SPRINT action ~RunningAttack~
+        END ELSE BEGIN
+          TEXT_SPRINT action ~Attack~
         END
-        SET pos = pos2
+        SET index += 1
       END
-      SET index += 1
-    END
+      ~%action%(~
   END
 BUT_ONLY

--- a/eefixpack/files/tph/pstee.tph
+++ b/eefixpack/files/tph/pstee.tph
@@ -49,6 +49,7 @@ INCLUDE ~eefixpack/files/tph/pst_wed_fixes.tph~ // WED-specific fixes
 ///// creature file fixes                              \\\\\
 /////                                                  \\\\\
 
+// Fixing creature script names
 COPY_EXISTING ~apprent2.cre~ ~override~
               ~apprent3.cre~ ~override~
               ~apprent4.cre~ ~override~
@@ -56,11 +57,46 @@ COPY_EXISTING ~apprent2.cre~ ~override~
   WRITE_ASCII DEATHVAR ~None~ (32)
 BUT_ONLY
 
+// Fixing creature race
+ACTION_DEFINE_ASSOCIATIVE_ARRAY cre_race BEGIN
+  // resref   => RACE.IDS value
+  ~bsohmien~  => 59   // SOHMIEN
+  ~hbdygrd~   => 1    // HUMAN
+  ~lady~      => 38   // LADY_OF_PAIN
+  ~trias~     => 14   // DEVA
+  ~triasa~    => 14   // DEVA
+  ~triasb~    => 14   // DEVA
+  ~triasc~    => 14   // DEVA
+  ~worm~      => 71   // WORM
+END
+
+ACTION_PHP_EACH cre_race AS resref => race BEGIN
+  COPY_EXISTING ~%resref%.cre~ ~override~
+    WRITE_BYTE 0x272 race
+  BUT_ONLY
+END
+
 INCLUDE ~eefixpack/files/tph/pst_cre_color_fixes.tph~ // creature color fixes
 
 /////                                                  \\\\\
 ///// item file fixes                                  \\\\\
 /////                                                  \\\\\
+
+// The Number of Ku'u Yin should protect from Chaotic creatures
+COPY_EXISTING ~kyname.itm~ ~override~
+  LPF DELETE_ITEM_EQEFFECT INT_VAR opcode_to_delete = 0 END   // Remove: AC bonus
+  LPF DELETE_ITEM_EQEFFECT INT_VAR opcode_to_delete = 33 END  // Remove: Save vs. Death bonus
+  PATCH_FOR_EACH align IN ~49~ ~50~ ~51~ BEGIN // alignment: chaotic good/neutral/evil
+    LPF ADD_ITEM_EQEFFECT
+    INT_VAR
+      opcode        = 219   // AC vs. Creature Type Modifier
+      target        = 1     // Self
+      timing        = 2     // While equipped
+      parameter1    = align // IDS value
+      parameter2    = 8     // IDS target: ALIGN.IDS
+    END
+  END
+BUT_ONLY
 
 /////                                                  \\\\\
 ///// spell fixes                                      \\\\\


### PR DESCRIPTION
Changes:
- Fixed race of selected creatures
- Improved combat scripts to provide running attacks only to suitable creatures
- Fixed item "The Number of Ku'u Yin": Protect from Chaotic creatures
  - Provides now +2 AC and saving throw bonus vs chaotic creatures (as indicated in item description)
- Vrishika's Curiosity Shop: fixed price paid for the Monster Jug
- Kitla's dialog: fixed duplicate journal entries; removed a redundant journal entry
- Fall-from-Grace's dialog: fixed duplicate journal entries
- Fall-from-Grace's dialog: fixed duplicate reply string
- Pillar of Skulls dialog: fixed duplicate journal entries