### PR TITLE
Natural creature weapons (from Polymorph abilities) and Touch attacks should not benefit from Fighting Styles

### DIFF
--- a/eefixpack/files/lua/luke/m_cdprof.lua
+++ b/eefixpack/files/lua/luke/m_cdprof.lua
@@ -6,7 +6,7 @@ function AreWeaponProficienciesModified()
 	local f = {};
 	f[143] = true; -- check for the Maze icon (since the Maze icon is in the default "STATES.BAM", we need to check index, not BAM. Values 0 – 190 are drawn directly from "STATES.BAM" from sequences 65 – 255, so: 65 + 78 = 143)
 	f["SPPR750D"] = true; -- check for the Ether Gate (Shaman Maze) icon
-	f["WEAPPROF"] = true; -- custom portrait icon for Weapon Proficiencies Altered
+	f["WEAPPROF"] = true; -- custom portrait icon for Weapon Proficiencies Modification
 	for k, v in pairs(characters[currentID].statusEffects) do
 		if f[v.bam] == true then
 			return false

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -266,12 +266,16 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
-// luke
-// Shocking Grasp – should not interact with spell protections
+/*
+luke
+**Shocking Grasp**
+- Should not interact with level-based spell protections
+- It now casts a `SPL` file that scales with level (up to `20`)
+  - (instead of using `20` different `ITM` files)
+*/
 WITH_SCOPE BEGIN
-  COPY_EXISTING "sgrasp19.itm" "override"
-    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~power~ = 0 END
-  BUT_ONLY_IF_IT_CHANGES
+  INCLUDE "eefixpack/files/tph/luke/shocking_grasp.tph"
+  LAUNCH_ACTION_FUNCTION "WIZARD_SHOCKING_GRASP" END
 END
 
 // luke
@@ -343,6 +347,22 @@ END
 WITH_SCOPE BEGIN
   INCLUDE "eefixpack/files/tph/luke/searing_orb.tph"
   LAUNCH_ACTION_FUNCTION ~CLERIC_SOL_SEARING_ORB~ END
+END
+
+/*
+luke
+**Magical Weapon Slot**
+(Based on the previous tweak to the Black Blade of Disaster)
+- Make sure natural creature weapons / touch attacks do not benefit from Fighting Styles
+*/
+WITH_SCOPE BEGIN
+  WITH_TRA
+    "eefixpack/languages/en_us/luke/shared.tra"
+    "eefixpack/languages/%LANGUAGE%/luke/shared.tra"
+  BEGIN
+    INCLUDE "eefixpack/files/tph/luke/magical_weapon_slot.tph"
+    LAUNCH_ACTION_FUNCTION "MAGICAL_WEAPON_SLOT" END
+  END
 END
 
 // tbd, cam

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -270,6 +270,7 @@ END
 luke
 **Shocking Grasp**
 - Should not interact with level-based spell protections
+- Delete expiry sound since the spell can end prematurely
 - It now casts a `SPL` file that scales with level (up to `20`)
   - (instead of using `20` different `ITM` files)
 */

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -579,12 +579,16 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
-// luke
-// Shocking Grasp – should not interact with spell protections
+/*
+luke
+**Shocking Grasp**
+- Should not interact with level-based spell protections
+- It now casts a `SPL` file that scales with level (up to `20`)
+  - (instead of using `20` different `ITM` files)
+*/
 WITH_SCOPE BEGIN
-  COPY_EXISTING "sgrasp19.itm" "override"
-    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~power~ = 0 END
-  BUT_ONLY_IF_IT_CHANGES
+  INCLUDE "eefixpack/files/tph/luke/shocking_grasp.tph"
+  LAUNCH_ACTION_FUNCTION "WIZARD_SHOCKING_GRASP" END
 END
 
 // luke
@@ -656,6 +660,22 @@ END
 WITH_SCOPE BEGIN
   INCLUDE "eefixpack/files/tph/luke/searing_orb.tph"
   LAUNCH_ACTION_FUNCTION ~CLERIC_SOL_SEARING_ORB~ END
+END
+
+/*
+luke
+**Magical Weapon Slot**
+(Based on the previous tweak to the Black Blade of Disaster)
+- Make sure natural creature weapons / touch attacks do not benefit from Fighting Styles
+*/
+WITH_SCOPE BEGIN
+  WITH_TRA
+    "eefixpack/languages/en_us/luke/shared.tra"
+    "eefixpack/languages/%LANGUAGE%/luke/shared.tra"
+  BEGIN
+    INCLUDE "eefixpack/files/tph/luke/magical_weapon_slot.tph"
+    LAUNCH_ACTION_FUNCTION "MAGICAL_WEAPON_SLOT" END
+  END
 END
 
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -583,6 +583,7 @@ END
 luke
 **Shocking Grasp**
 - Should not interact with level-based spell protections
+- Delete expiry sound since the spell can end prematurely
 - It now casts a `SPL` file that scales with level (up to `20`)
   - (instead of using `20` different `ITM` files)
 */

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -373,6 +373,32 @@ WITH_SCOPE BEGIN
   END
 END
 
+/*
+luke
+**Iron Body**
+- Move spell features from `SPL` file to `ITM` file
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/luke/iron_body.tph"
+  LAUNCH_ACTION_FUNCTION "WIZARD_IRON_BODY" END
+END
+
+/*
+luke
+**Magical Weapon Slot**
+(Based on the previous tweak to the Black Blade of Disaster)
+- Make sure natural creature weapons / touch attacks do not benefit from Fighting Styles
+*/
+WITH_SCOPE BEGIN
+  WITH_TRA
+    "eefixpack/languages/en_us/luke/shared.tra"
+    "eefixpack/languages/%LANGUAGE%/luke/shared.tra"
+  BEGIN
+    INCLUDE "eefixpack/files/tph/luke/magical_weapon_slot.tph"
+    LAUNCH_ACTION_FUNCTION "MAGICAL_WEAPON_SLOT" END
+  END
+END
+
 /////                                                  \\\\\
 ///// spell fixes                                      \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/luke/iron_body.tph
+++ b/eefixpack/files/tph/luke/iron_body.tph
@@ -1,0 +1,37 @@
+DEFINE_ACTION_FUNCTION "WIZARD_IRON_BODY"
+BEGIN
+	// SPL file
+	COPY_EXISTING "%WIZARD_IRON_BODY%.spl" "override"
+		LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 1 END // already present on "ibody.itm"
+		LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 321 STR_VAR "match_resource" = "%DEST_RES%" END // useless (`op111` does not leave behind a removable effect)
+		SET "#_effects" = SHORT_AT (LONG_AT 0x64 + 0x1E) // # effects on the 1st ability
+		READ_ASCII (LONG_AT 0x6A + 0x30 * SHORT_AT 0x70) "effects_data" (0x30 * "%#_effects%") // store all effects (1st ability)
+		PATCH_WITH_SCOPE BEGIN
+			FOR ("i" = 0 ; "%i%" < "%#_effects%" ; "i" += 1) BEGIN // loop through all effects on the 1st ability
+				SET "match_opcode" = SHORT_AT (LONG_AT 0x6A + 0x30 * SHORT_AT 0x70 + "%i%" * 0x30 + 0x0) // current effect ID
+				SET "match_timing" = BYTE_AT (LONG_AT 0x6A + 0x30 * SHORT_AT 0x70 + "%i%" * 0x30 + 0xC) // current `timing_mode`
+				PATCH_MATCH "%match_timing%" WITH
+					"0" WHEN ("%match_opcode%" != 111) BEGIN
+						LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "multi_match" = 1 "match_opcode" END // delete one effect at a time (the function does not return the number of deleted effects)
+						// We need to take into account the effect we've just deleted
+						SET "#_effects" -= 1 // total number of effects
+						SET "i" -= 1 // current index
+					END
+					DEFAULT
+				END
+			END
+		END
+	BUT_ONLY_IF_IT_CHANGES
+	// ITM file
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "ibody.itm" "override"
+			INSERT_BYTES 0xAA STRING_LENGTH "%effects_data%"
+			WRITE_ASCIIE 0xAA "%effects_data%"
+			WRITE_SHORT 0x70 (THIS + "%#_effects%")
+			LPF ~FJ_SPL_ITM_REINDEX~ END // re-index the file
+			// Clean up
+			LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 111 END // Create weapon
+			LPF "ALTER_EFFECT" INT_VAR "check_headers" = 0 "target" = 1 "power" = 0 "resist_dispel" = 0 "timing" = 2 "duration" = 0 END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END

--- a/eefixpack/files/tph/luke/iron_body.tph
+++ b/eefixpack/files/tph/luke/iron_body.tph
@@ -31,6 +31,7 @@ BEGIN
 			LPF ~FJ_SPL_ITM_REINDEX~ END // re-index the file
 			// Clean up
 			LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 111 END // Create weapon
+			LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_timing" = 1 END
 			LPF "ALTER_EFFECT" INT_VAR "check_headers" = 0 "target" = 1 "power" = 0 "resist_dispel" = 0 "timing" = 2 "duration" = 0 END
 		BUT_ONLY_IF_IT_CHANGES
 	END

--- a/eefixpack/files/tph/luke/magical_weapon_slot.tph
+++ b/eefixpack/files/tph/luke/magical_weapon_slot.tph
@@ -1,0 +1,188 @@
+DEFINE_ACTION_FUNCTION "MAGICAL_WEAPON_SLOT"
+BEGIN
+	/* Disable SWORDANDSHIELD and SINGLEWEAPON */
+	// Auxiliary EFF file
+	WITH_SCOPE BEGIN
+		CREATE "EFF" "cdwstyl1"
+			WRITE_LONG 0x10 146 // Cast spell
+			WRITE_LONG 0x20 1 // Cast instantly (ignore level)
+			WRITE_LONG 0x24 1 // Instant/Permanent until death
+			WRITE_SHORT 0x2C 100 // Probability 1
+			WRITE_ASCII 0x30 "cdwstyl1" #8 // SPL file
+	END
+	// Auxiliary SPL file
+	WITH_SCOPE BEGIN
+		CREATE "SPL" "cdwstyl1"
+			WRITE_LONG NAME1 ~-1~
+			WRITE_LONG NAME2 ~-1~
+			WRITE_LONG UNIDENTIFIED_DESC ~-1~
+			WRITE_LONG DESC ~-1~
+			WRITE_LONG 0x34 1 // Level
+			//WRITE_ASCIIE 0x3A ~%WIZARD_BLACK_BLADE_OF_DISASTER%C~ #8 // Spell icon
+			WRITE_LONG 0x64 0x72 // Abilities offset
+			WRITE_SHORT 0x68 1 // # abilities
+			WRITE_LONG 0x6a 0x9a // Effects offset
+			INSERT_BYTES 0x72 0x28
+			/* Extended Header */
+			//WRITE_ASCIIE 0x76 ~%WIZARD_BLACK_BLADE_OF_DISASTER%B~ #8 // Icon
+			WRITE_SHORT 0x80 32767 // Range
+			WRITE_SHORT 0x82 1 // Minimum level
+			WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
+			/* Feature blocks */
+			// Prevent self stacking (`op272` can trigger under unintended circumstances...)
+			LAUNCH_PATCH_FUNCTION "ADD_SPELL_EFFECT"
+			INT_VAR
+				"opcode" = 321 // Remove effects by resource
+				"target" = 1
+				"timing" = 1
+			STR_VAR
+				"resource" = "cdwstyl1"
+			END
+			LAUNCH_PATCH_FUNCTION "ADD_SPELL_EFFECT"
+			INT_VAR
+				"opcode" = 233 // Modify proficiencies
+				"target" = 1
+				"parameter1" = 0 // Set to 0
+				"parameter2" = IDS_OF_SYMBOL ("WPROF" "PROFICIENCYSWORDANDSHIELD")
+				"duration" = 2 // Remember that Slow doubles the timing rate of `op272`!
+			END
+			LAUNCH_PATCH_FUNCTION "ADD_SPELL_EFFECT"
+			INT_VAR
+				"opcode" = 233 // Modify proficiencies
+				"target" = 1
+				"parameter1" = 0 // Set to 0
+				"parameter2" = IDS_OF_SYMBOL ("WPROF" "PROFICIENCYSINGLEWEAPON")
+				"duration" = 2 // Remember that Slow doubles the timing rate of `op272`!
+			END
+			PATCH_WITH_SCOPE BEGIN
+				LAUNCH_PATCH_FUNCTION "ADD_STATDESC_ENTRY"
+				INT_VAR
+					"description" = RESOLVE_STR_REF (@100000)
+				STR_VAR
+					"bam_file" = "weapprof"
+				RET
+					"index"
+				END
+				LAUNCH_PATCH_FUNCTION "ADD_SPELL_EFFECT"
+				INT_VAR
+					"opcode" = 142 // Display portrait icon
+					"target" = 1
+					"parameter2" = "%index%"
+					"duration" = 2 // Remember that Slow doubles the timing rate of `op272`!
+				END
+			END
+	END
+	/* Disable SWORDANDSHIELD */
+	// Auxiliary EFF file
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "cdwstyl1.eff" "override/cdwstyl2.eff"
+			WRITE_ASCII 0x30 "cdwstyl2" #8 // SPL file
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// Auxiliary SPL file
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "cdwstyl1.spl" "override/cdwstyl2.spl"
+			/* Feature blocks */
+			LAUNCH_PATCH_FUNCTION "DELETE_EFFECT"
+			INT_VAR
+				"match_opcode" = 233 // Modify proficiencies
+				"check_globals" = 0
+				"match_parameter2" = IDS_OF_SYMBOL ("WPROF" "PROFICIENCYSINGLEWEAPON")
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// Main
+	WITH_SCOPE BEGIN
+		COPY_EXISTING
+			~sgrasp.itm~ ~override~ // Shocking Grasp
+			~bclaw.itm~ ~override~ // Beast Claw
+			~seriuos.itm~ ~override~ // Cause Serious Wounds
+			~critical.itm~ ~override~ // Cause Critical Wounds
+			~slaylive.itm~ ~override~ // Slay Living
+			~harm.itm~ ~override~ // Harm
+			~ctouch.itm~ ~override~ // Chill Touch (iwd)
+			~chillt.itm~ ~override~ // Chill Touch (bg)
+			~ghoult.itm~ ~override~ // Ghoul Touch
+			~ltouch.itm~ ~override~ // Lich Touch
+			~ibody.itm~ ~override~ // Iron Body
+			/* Polymorph Self */
+			~plybear1.itm~ ~override~ // Shapeshift: Brown Bear
+			~plybear2.itm~ ~override~ // Shapeshift: Black Bear
+			~plyflind.itm~ ~override~ // Shapeshift: Flind
+			~plymstar.itm~ ~override~ // Shapeshift: Ogre
+			~plyspid.itm~ ~override~ // Shapeshift: Spider
+			~plywolf1.itm~ ~override~ // Shapeshift: Wolf
+			~cdpolybb.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
+			~cdpolypb.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
+			~cdpolyww.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
+			/* Shapechange */
+			~cdmindfl.itm~ ~override~ // Shapechange: Mind Flayer
+			~cdgoliro.itm~ ~override~ // Shapechange: Iron Golem
+			~trollall.itm~ ~override~ // Shapechange: Giant Troll
+			~wolfgr.itm~ ~override~ // Shapechange: Greater Wolfwere
+			~firern.itm~ ~override~ // Shapechange: Fire Elemental
+			~earthrn.itm~ ~override~ // Shapechange: Earth Elemental
+			~cdshwele.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
+			/* Unkitted Druid */
+			~brbrp.itm~ ~override~ // Shapeshift: Brown Bear (bg)
+			~wolfm.itm~ ~override~ // Shapeshift: Wolf (bg)
+			~brblp.itm~ ~override~ // Shapeshift: Black Bear (bg)
+			~plypbear.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
+			~plywwolf.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
+			~plybeetl.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
+			~felem.itm~ ~override~ // Shapeshift: Fire Elemental (iwd)
+			~eelem.itm~ ~override~ // Shapeshift: Earth Elemental (iwd)
+			~welem.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
+			/* Avenger (Druid) */
+			~plyspid2.itm~ ~override~ // Shapeshift: Sword Spider
+			~plywyvrn.itm~ ~override~ // Shapeshift: Baby Wyvern
+			~plybass.itm~ ~override~ // Shapeshift: Lesser Basilisk (old, unused)
+			/* Shapeshifter (Druid) */
+			~brbrp1.itm~ ~override~ // Shapeshift: Werewolf (bg)
+			~brbrp2.itm~ ~override~ // Shapeshift: Greater Werewolf (bg)
+			~cdbrbrp.itm~ ~override~ // Shapeshift: Werewolf (bg)
+			~cdbrbrp2.itm~ ~override~ // Shapeshift: Greater Werewolf (bg2)
+			~werewfl1.itm~ ~override~ // Shapeshift: Werewolf (bg)
+			~werewfl2.itm~ ~override~ // Shapeshift: Greater Werewolf (iwd)
+			/* Other */
+			~squirp.itm~ ~override~ // Polymorph Other
+			~wswolf.itm~ ~override~ // Polymorph Other (wild surge)
+			~cdwolfm.itm~ ~override~ // Relair's Mistake
+			~polyrat.itm~ ~override~ // Cloak of the Sewers (Rat)
+			~plytroll.itm~ ~override~ // Cloak of the Sewers (Troll)
+			~drufir.itm~ ~override~ // Fire Elemental Transformation
+			~druear.itm~ ~override~ // Earth Elemental Transformation
+			~slayerw1.itm~ ~override~ // Slayer Change
+			~slayerw2.itm~ ~override~ // Slayer Change
+			~slayerw3.itm~ ~override~ // Slayer Change
+			~slayerw4.itm~ ~override~ // Slayer Change
+			PATCH_MATCH "%DEST_RES%" WITH
+				~plymstar~ BEGIN
+					LAUNCH_PATCH_FUNCTION "ADD_ITEM_EQEFFECT"
+					INT_VAR
+						"insert_point" = "-1" // Last
+						"opcode" = 272 // Use EFF file on condition
+						"target" = 1
+						"parameter1" = 1 // any non-zero value
+						"parameter2" = 0 // Once per second
+						"timing" = 2
+					STR_VAR
+						"resource" = "cdwstyl2"
+					END
+				END
+				DEFAULT
+					LAUNCH_PATCH_FUNCTION "ADD_ITEM_EQEFFECT"
+					INT_VAR
+						"insert_point" = "-1" // Last
+						"opcode" = 272 // Use EFF file on condition
+						"target" = 1
+						"parameter1" = 1 // any non-zero value
+						"parameter2" = 0 // Once per second
+						"timing" = 2
+					STR_VAR
+						"resource" = "cdwstyl1"
+					END
+			END
+		BUT_ONLY IF_EXISTS
+	END
+END

--- a/eefixpack/files/tph/luke/magical_weapon_slot.tph
+++ b/eefixpack/files/tph/luke/magical_weapon_slot.tph
@@ -108,7 +108,6 @@ BEGIN
 			/* Polymorph Self */
 			~plybear1.itm~ ~override~ // Shapeshift: Brown Bear
 			~plybear2.itm~ ~override~ // Shapeshift: Black Bear
-			~plyflind.itm~ ~override~ // Shapeshift: Flind
 			~plymstar.itm~ ~override~ // Shapeshift: Ogre
 			~plyspid.itm~ ~override~ // Shapeshift: Spider
 			~plywolf1.itm~ ~override~ // Shapeshift: Wolf

--- a/eefixpack/files/tph/luke/polymorph_overhaul.tph
+++ b/eefixpack/files/tph/luke/polymorph_overhaul.tph
@@ -1046,6 +1046,7 @@ BEGIN
 						WRITE_BYTE 0x88 10 // Dicesize
 						WRITE_BYTE 0x8A 4 // Dicenumber
 						WRITE_SHORT 0x8E 2 // Damage type: Crushing
+						WRITE_SHORT 0x92 SHORT_AT 0x70 // First effect index (we need to take into account equipped effects!)
 						WRITE_SHORT 0x96 1 // Item vanishes
 						WRITE_LONG 0x98 BIT0 // Add STR bonus
 						WRITE_SHORT 0x9C IDS_OF_SYMBOL ("MISSILE" "None") // Projectile

--- a/eefixpack/files/tph/luke/shocking_grasp.tph
+++ b/eefixpack/files/tph/luke/shocking_grasp.tph
@@ -12,6 +12,12 @@ BEGIN
 			STR_VAR
 				"resource" = "SGRASP"
 			END
+			// Delete expiry sound since the spell can end prematurely
+			LPF "DELETE_EFFECT"
+			INT_VAR
+				"match_opcode" = 174 // Play sound
+				"match_timing" = 4 // Delay/Permanent
+			END
 		BUT_ONLY_IF_IT_CHANGES
 	END
 	// ITM file

--- a/eefixpack/files/tph/luke/shocking_grasp.tph
+++ b/eefixpack/files/tph/luke/shocking_grasp.tph
@@ -1,0 +1,93 @@
+DEFINE_ACTION_FUNCTION "WIZARD_SHOCKING_GRASP"
+BEGIN
+	// Let us use a unique ITM file for all character levels
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "%WIZARD_SHOCKING_GRASP%.spl" "override"
+			/* Header */
+			WRITE_BYTE 0x27 12 // COMBATPROTECTIONS => COMBINATION
+			/* Feature blocks */
+			LPF "ALTER_EFFECT"
+			INT_VAR
+				"match_opcode" = 111 // Create weapon
+			STR_VAR
+				"resource" = "SGRASP"
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// ITM file
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "sgrasp.itm" "override"
+			/* Header */
+			WRITE_LONG 0x18 THIS BOR IDS_OF_SYMBOL ("itemflag" "SILVER") BOR IDS_OF_SYMBOL ("itemflag" "COLDIRON")
+			WRITE_ASCII 0x3A "ISGRASP" #8 // Inventory icon
+			/* Extended header */
+			LPF "ALTER_ITEM_HEADER"
+			INT_VAR
+				"range" = 0 // Touch attack
+			STR_VAR
+				"icon" = "ISGRASP"
+			END
+			/* Feature blocks */
+			LPF "DELETE_EFFECT" END // delete current content
+			LPF "ADD_ITEM_EFFECT"
+			INT_VAR
+				"type" = 1 // Melee headers
+				"opcode" = 146 // Cast spell
+				"target" = 2
+				"parameter2" = 1 // Cast instantly (ignore level)
+				"timing" = 1
+			STR_VAR
+				"resource" = "%DEST_RES%"
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+	// Auxiliary subspell
+	WITH_SCOPE BEGIN
+		CREATE "SPL" "sgrasp"
+			WRITE_LONG NAME1 ~-1~
+			WRITE_LONG NAME2 ~-1~
+			WRITE_LONG UNIDENTIFIED_DESC ~-1~
+			WRITE_LONG DESC ~-1~
+			WRITE_LONG 0x18 BIT14 // Ignore dead/wild magic
+			WRITE_SHORT 0x1C 1 // Spell type: wizard
+			WRITE_BYTE 0x25 8 // TRANSMUTER
+			WRITE_BYTE 0x27 10 // OFFENSIVEDAMAGE
+			WRITE_LONG 0x34 1 // Level
+			WRITE_ASCIIE 0x3A ~%WIZARD_SHOCKING_GRASP%C~ #8 // Spell icon
+			WRITE_LONG 0x64 0x72 // Abilities offset
+			WRITE_SHORT 0x68 1 // # abilities
+			WRITE_LONG 0x6a 0x9a // Effects offset
+			INSERT_BYTES 0x72 0x28
+			/* Extended Header */
+			WRITE_ASCIIE 0x76 ~%WIZARD_SHOCKING_GRASP%B~ #8 // Icon
+			WRITE_SHORT 0x80 32767 // Range
+			WRITE_SHORT 0x82 1 // Minimum level
+			WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
+			// Extend up to character level 20
+			LPF "CD_EXTEND-O-MATIC" END
+			/* Feature blocks */
+			// "... an electrical charge will deal 1d8 points of damage plus 1 per level of the caster..."
+			PATCH_WITH_SCOPE BEGIN
+				FOR ("i" = 1 ; "%i%" <= SHORT_AT 0x68 ; "i" += 1) BEGIN
+					LPF "ADD_SPELL_EFFECT"
+					INT_VAR
+						"header" = "%i%"
+						"opcode" = 12 // Damage
+						"target" = 2
+						"parameter1" = "%i%"
+						"parameter2" = IDS_OF_SYMBOL ("dmgtype" "ELECTRICITY")
+						"timing" = 1
+						"dicenumber" = 1
+						"dicesize" = 8
+					END
+				END
+			END
+			LPF "ADD_SPELL_EFFECT"
+			INT_VAR
+				"opcode" = 141 // Lighting effects
+				"target" = 2
+				"parameter2" = 6 // Alteration water
+				"timing" = 1
+			END
+	END
+END

--- a/eefixpack/languages/en_us/fixes_iwdee.tra
+++ b/eefixpack/languages/en_us/fixes_iwdee.tra
@@ -440,7 +440,7 @@ The Druid is healed 12 Hit Points after using this ability."
 luke
 "strikes as a +4 weapon" should not be missing
 */
-@40413 = "Shapeshift: Water Elemental
+@40313 = "Shapeshift: Water Elemental
 
 Strength: 18
 Dexterity: 14


### PR DESCRIPTION
- Fixed typo in `eefixpack/languages/en_us/fixes_iwdee.tra`
- Make sure `cdgoliro.itm` has no mis-indexed effects
- **Shocking Grasp** [bg, bg2]
  - Should not interact with level-based spell protections
  - Make sure `secondary_type` is `COMBINATION` (instead of `COMBATPROTECTIONS`)
  - Delete expiry sound since the spell can end prematurely
  - It now casts a `SPL` file that scales with level (up to `20`)
    - (instead of using `20` different `ITM` files)
- **Iron Body** [iwd]
  - Move spell features from `SPL` file to `ITM` file
- Make sure natural creature weapons (from Polymorph abilities) / touch attacks do not benefit from Fighting Styles
  - this is based on the previous tweak to the [Black Blade of Disaster](https://github.com/Gibberlings3/EE_Fixpack/pull/15).