### PR TITLE
Polymorph abilities (minor fixes)

### DIFF
--- a/eefixpack/files/tph/luke/polymorph_overhaul.tph
+++ b/eefixpack/files/tph/luke/polymorph_overhaul.tph
@@ -586,6 +586,14 @@ BEGIN
 					END
 					COPY_EXISTING ~%file_%~ ~override~
 						//TO_UPPER ~SOURCE_RES~
+						/* Header */
+						PATCH_MATCH "%DEST_RES%" WITH
+							"%SHAPECHANGE_WATER_ELEMENTAL%" BEGIN
+								WRITE_LONG UNIDENTIFIED_DESC RESOLVE_STR_REF (@2)
+								WRITE_LONG DESC ~-1~ // unused
+							END
+							DEFAULT
+						END
 						LPF "DELETE_EFFECT" END // delete current content
 						PATCH_IF !(IS_AN_INT $"x"("2")) BEGIN // Polymorph Self / Shapechange - usable at will
 							SPRINT $ $"x"("2")(~%resource%~) $~item~(~~) // This instruction is supposed to generate an array containing the various special abilities granted by Polymorph Self / Shapechange (f.i.: Shapechange: Mind Flayer, Shapechange: Iron Golem, etc...)
@@ -1129,7 +1137,7 @@ BEGIN
 						LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 142 "match_parameter2" = 38 END // Display portrait icon (Haste) => this is supposed to be Movement rate bonus, not haste
 					END
 					"CDMINDFL" BEGIN // Shapechange: Mind Flayer
-						LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 139 "parameter1" = RESOLVE_STR_REF (@2) "parameter2" = 0 "timing" = 1 "duration" = 0 STR_VAR "resource" = "" END
+						LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 139 "parameter1" = RESOLVE_STR_REF (@3) "parameter2" = 0 "timing" = 1 "duration" = 0 STR_VAR "resource" = "" END
 					END
 					DEFAULT
 				END
@@ -1206,5 +1214,14 @@ BEGIN
 			WRITE_BYTE 0x238 15 // Strength
 			WRITE_BYTE 0x23C 18 // Dexterity
 		BUT_ONLY IF_EXISTS
+	END
+	// ~%SHAPECHANGE_GIANT_TROLL%~ => Strength: 18/100 (so as to match description)
+	WITH_SCOPE BEGIN
+		ACTION_IF (GAME_IS ~iwdee~) BEGIN
+			COPY_EXISTING ~shtroll.cre~ ~override~
+				WRITE_BYTE 0x238 18 // Strength
+				WRITE_BYTE 0x239 100 // Strength bonus
+			BUT_ONLY_IF_IT_CHANGES
+		END
 	END
 END

--- a/eefixpack/languages/en_us/fixes_iwdee.tra
+++ b/eefixpack/languages/en_us/fixes_iwdee.tra
@@ -642,7 +642,8 @@ Special Abilities:
 
 /*
 luke
-"strikes as a +4 weapon" should not be missing
+- "strikes as a +4 weapon" should not be missing
+- Added missing 15% acid and electricity resist
 */
 @36184 = "Shapechange: Fire Elemental
 
@@ -656,6 +657,8 @@ Attack Damage: 1d8 (crushing), +1d4 fire, strikes as a +4 weapon
 Special Abilities:
 – Cold Resistance: -50%
 – Fire Resistance: 100%
+– Acid Resistance: 15%
+– Electricity Resistance: 15%
 – Slashing Resistance: 15%
 – Crushing Resistance: 15%
 – Piercing Resistance: 15%
@@ -663,7 +666,8 @@ Special Abilities:
 
 /*
 luke
-"strikes as a +4 weapon" should not be missing
+- "strikes as a +4 weapon" should not be missing
+- fire and cold resist should be 25%, not 20%
 */
 @36186 = "Shapechange: Earth Elemental
 
@@ -675,32 +679,9 @@ Number of Attacks: 1
 Attack Damage: 4d8 (crushing), strikes as a +4 weapon
 
 Special Abilities:
-– Cold Resistance: 20%
-– Fire Resistance: 20%
+– Cold Resistance: 25%
+– Fire Resistance: 25%
 – Slashing Resistance: 50%
 – Crushing Resistance: -50%
 – Piercing Resistance: 50%
-– Missile Resistance: 75%"
-
-/*
-luke
-- "strikes as a +4 weapon" should not be missing
-- "The Druid is healed 12 Hit Points after using this ability." should be missing (this is not the Druid variant)
-*/
-@40313 = "Shapeshift: Water Elemental
-
-Strength: 18
-Dexterity: 14
-
-Base Armor Class: -2
-Number of Attacks: 1
-Attack Damage: 4d8 (crushing), strikes as a +4 weapon
-
-Special Abilities:
-– Cold Resistance: -25%
-– Electricity Resistance: -75%
-– Acid Resistance: 75%
-– Slashing Resistance: 75%
-– Crushing Resistance: 75%
-– Piercing Resistance: 75%
 – Missile Resistance: 75%"

--- a/eefixpack/languages/en_us/fixes_iwdee.tra
+++ b/eefixpack/languages/en_us/fixes_iwdee.tra
@@ -417,7 +417,9 @@ Attack Damage: 1d8 (crushing), +1d4 fire, strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: -50%
+– Magic Cold Resistance: -50%
 – Fire Resistance: 100%
+– Magic Fire Resistance: 100%
 – Acid Resistance: 15%
 – Electricity Resistance: 15%
 – Slashing Resistance: 15%
@@ -442,7 +444,9 @@ Attack Damage: 4d8 (crushing), strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: 25%
+– Magic Cold Resistance: 25%
 – Fire Resistance: 25%
+– Magic Fire Resistance: 25%
 – Slashing Resistance: 50%
 – Crushing Resistance: -50%
 – Piercing Resistance: 50%
@@ -465,6 +469,7 @@ Attack Damage: 4d8 (crushing), strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: -25%
+– Magic Cold Resistance: -25%
 – Electricity Resistance: -75%
 – Acid Resistance: 75%
 – Slashing Resistance: 75%
@@ -656,7 +661,9 @@ Attack Damage: 1d8 (crushing), +1d4 fire, strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: -50%
+– Magic Cold Resistance: -50%
 – Fire Resistance: 100%
+– Magic Fire Resistance: 100%
 – Acid Resistance: 15%
 – Electricity Resistance: 15%
 – Slashing Resistance: 15%
@@ -680,7 +687,9 @@ Attack Damage: 4d8 (crushing), strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: 25%
+– Magic Cold Resistance: 25%
 – Fire Resistance: 25%
+– Magic Fire Resistance: 25%
 – Slashing Resistance: 50%
 – Crushing Resistance: -50%
 – Piercing Resistance: 50%

--- a/eefixpack/languages/en_us/luke/polymorph_overhaul.tra
+++ b/eefixpack/languages/en_us/luke/polymorph_overhaul.tra
@@ -2,4 +2,26 @@
 
 @1 = ~Shapeshift: Natural Form (Shapechange)~
 
-@2 = "Devour brain"
+/*
+IWD:EE, @40313: This is used for both the druid shapeshift and the mage shapechange. A new text string should be created for the Shapechange version.
+Notably, "The Druid is healed 12 Hit Points after using this ability." should be missing in the mage shapechange
+*/
+@2 = "Shapeshift: Water Elemental
+
+Strength: 18
+Dexterity: 14
+
+Base Armor Class: -2
+Number of Attacks: 1
+Attack Damage: 4d8 (crushing), strikes as a +4 weapon
+
+Special Abilities:
+– Cold Resistance: -25%
+– Electricity Resistance: -75%
+– Acid Resistance: 75%
+– Slashing Resistance: 75%
+– Crushing Resistance: 75%
+– Piercing Resistance: 75%
+– Missile Resistance: 75%"
+
+@3 = "Devour brain"

--- a/eefixpack/languages/en_us/luke/polymorph_overhaul.tra
+++ b/eefixpack/languages/en_us/luke/polymorph_overhaul.tra
@@ -17,6 +17,7 @@ Attack Damage: 4d8 (crushing), strikes as a +4 weapon
 
 Special Abilities:
 – Cold Resistance: -25%
+– Magic Cold Resistance: -25%
 – Electricity Resistance: -75%
 – Acid Resistance: 75%
 – Slashing Resistance: 75%


### PR DESCRIPTION
- [iwd] Added missing **Magic Fire/Cold** resistances
- [iwd] **@40313 => Shapeshift: Water Elemental**
  - This is used for both the druid shapeshift and the mage shapechange. A new text string has been created for the Shapechange version
  - Notably, _"The Druid is healed 12 Hit Points after using this ability."_ should be missing in the mage shapechange
- [iwd] **@36184 => Shapechange: Fire Elemental**
  - Added missing `15%` acid and electricity resist
- [iwd] **@36186 => Shapechange: Earth Elemental**
  - fire and cold resist should be `25%`, not `20%`
- [iwd] **@36180 => Shapechange: Giant Troll**
  - `CRE` file (`shtroll.cre`) should set Strength to `18/100`, not `18` (so as to match description)