### PR TITLE
Nishruu / Hakeashar

### DIFF
--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -1289,6 +1289,26 @@ WITH_SCOPE BEGIN
   END
 END
 
+/*
+luke
+Summon Nishruu / Hakeashar
+- their attack (`nishrusu.itm`) should ignore all `AC` modifiers
+  - previously, since it was using `damage_type=piercing`, the Nishruu (`THAC0=11`) would need to roll a Critical Hit in order to hit `AC -9 vs. piercing` attacks targets. A similar argument holds for the Hakeashar
+    - this is certainly unintended since they don't actually deal piercing damage
+- they should be vulnerable to Dispel/Remove Magic
+- they should be flagged as `GENERAL=MONSTER` / `RACE=MIST` / `CLASS=MIST` on all games
+- make sure the Nishruu has 100% Poison resistance
+- The Hakeashar should have the same passive traits as the Nishruu
+  - i.e., it should be immune to Poison and see invisible creatures
+- the Nishruu should use the `NISHRUU` animation on all games
+- the Hakeashar should use the `HAKEASHAR` animation on all games
+- removed unused spell setup
+*/
+WITH_SCOPE BEGIN
+  INCLUDE ~eefixpack/files/tph/luke/nishruu_hakeashar.tph~
+  LAF ~NISHRUU_HAKEASHAR~ END
+END
+
 // tbd, cam
 // don't play berserk damage warnings on non-party memebers; see also spin117[ab].eff
 INCLUDE ~eefixpack/files/tph/tbd_angry_noises.tph~

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -1688,6 +1688,26 @@ WITH_SCOPE BEGIN
   END
 END
 
+/*
+luke
+Summon Nishruu / Hakeashar
+- their attack (`nishrusu.itm`) should ignore all `AC` modifiers
+  - previously, since it was using `damage_type=piercing`, the Nishruu (`THAC0=11`) would need to roll a Critical Hit in order to hit `AC -9 vs. piercing` attacks targets. A similar argument holds for the Hakeashar
+    - this is certainly unintended since they don't actually deal piercing damage
+- they should be vulnerable to Dispel/Remove Magic
+- they should be flagged as `GENERAL=MONSTER` / `RACE=MIST` / `CLASS=MIST` on all games
+- make sure the Nishruu has 100% Poison resistance
+- The Hakeashar should have the same passive traits as the Nishruu
+  - i.e., it should be immune to Poison and see invisible creatures
+- the Nishruu should use the `NISHRUU` animation on all games
+- the Hakeashar should use the `HAKEASHAR` animation on all games
+- removed unused spell setup
+*/
+WITH_SCOPE BEGIN
+  INCLUDE ~eefixpack/files/tph/luke/nishruu_hakeashar.tph~
+  LAF ~NISHRUU_HAKEASHAR~ END
+END
+
 /////                                                  \\\\\
 ///// projectile fixes                                 \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -875,6 +875,26 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
+/*
+luke
+Summon Nishruu / Hakeashar
+- their attack (`nishrusu.itm`) should ignore all `AC` modifiers
+  - previously, since it was using `damage_type=piercing`, the Nishruu (`THAC0=11`) would need to roll a Critical Hit in order to hit `AC -9 vs. piercing` attacks targets. A similar argument holds for the Hakeashar
+    - this is certainly unintended since they don't actually deal piercing damage
+- they should be vulnerable to Dispel/Remove Magic
+- they should be flagged as `GENERAL=MONSTER` / `RACE=MIST` / `CLASS=MIST` on all games
+- make sure the Nishruu has 100% Poison resistance
+- The Hakeashar should have the same passive traits as the Nishruu
+  - i.e., it should be immune to Poison and see invisible creatures
+- the Nishruu should use the `NISHRUU` animation on all games
+- the Hakeashar should use the `HAKEASHAR` animation on all games
+- removed unused spell setup
+*/
+WITH_SCOPE BEGIN
+  INCLUDE ~eefixpack/files/tph/luke/nishruu_hakeashar.tph~
+  LAF ~NISHRUU_HAKEASHAR~ END
+END
+
 // tbd, cam
 // don't play berserk damage warnings on non-party memebers; see also spin117[ab].eff
 INCLUDE ~eefixpack/files/tph/tbd_angry_noises.tph~

--- a/eefixpack/files/tph/luke/nishruu_hakeashar.tph
+++ b/eefixpack/files/tph/luke/nishruu_hakeashar.tph
@@ -1,0 +1,154 @@
+DEFINE_ACTION_FUNCTION "NISHRUU_HAKEASHAR"
+BEGIN
+	// Let us add a new IDS entry to properly flag them
+	LAF "ADD_IDS_ENTRY"
+	INT_VAR
+		"minValue" = 1
+	STR_VAR
+		"idsFile" = "specific"
+		"identifier" = "NISHRUU_HAKEASHAR"
+	RET
+		"SPECIFIC_NISHRUU_HAKEASHAR" = "value"
+	END
+
+	// They should be vulnerable to Dispel/Remove Magic
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "nishru01.bcs" "override"
+			DECOMPILE_AND_PATCH BEGIN
+				SET "found" = INDEX_BUFFER (CASE_SENSITIVE EXACT_MATCH "SpellCastOnMe") // "SpellCastOnMe()" ignores "Any point within range" abilities (Target @ 0xC) when used by the player
+				SET "start" = RINDEX_BUFFER (CASE_SENSITIVE EVALUATE_REGEXP "^IF" "%found%")
+				SET "end" = INDEX_BUFFER (CASE_SENSITIVE EVALUATE_REGEXP "^END" "%found%")
+				DELETE_BYTES "%start%" ("%end%" + STRING_LENGTH "END" - "%start%")
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING
+			/* files to patch */
+			"%CLERIC_DISPEL_MAGIC%.spl" "override"
+			"%WIZARD_DISPEL_MAGIC%.spl" "override"
+			"%WIZARD_TRUE_DISPEL_MAGIC%.spl" "override"
+			"spin112.spl" "override" // Dispel Magic (Yeslick)
+			"%INQUIS_DISPEL_MAGIC%.spl" "override"
+			/* actual patch */
+			LAUNCH_PATCH_FUNCTION ~CLONE_EFFECT~ INT_VAR ~silent~ = 1 ~check_globals~ = 0 ~multi_match~ = 1 ~match_opcode~ = 58 ~opcode~ = 177 ~parameter1~ = ~%SPECIFIC_NISHRUU_HAKEASHAR%~ ~parameter2~ = 6 ~special~ = 0 STR_VAR ~resource~ = ~destself~ ~insert~ = ~below~ END // Use EFF file (SPECIFIC.IDS)
+		BUT_ONLY IF_EXISTS
+	END
+
+	/*WITH_SCOPE BEGIN
+		COPY_EXISTING_REGEXP "^.+\.\(itm\|spl\)$" "override"
+			PATCH_IF (SOURCE_SIZE > 0x71) BEGIN
+				PATCH_WITH_SCOPE BEGIN
+					PATCH_MATCH "%DEST_EXT%" WITH
+						"ITM" BEGIN
+							GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
+						END
+						"SPL" BEGIN
+							GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
+						END
+						DEFAULT
+							PATCH_FAIL "Should not happen"
+					END
+					PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+						LPF "COUNT_V10_HEAD_EFFECTS" STR_VAR "opcode" = "58" RET "count" END
+						LAUNCH_PATCH_FUNCTION ~CLONE_EFFECT~ INT_VAR ~silent~ = 1 ~header~ = ~%ab_ind%~ ~check_globals~ = 0 ~check_headers~ = (~%count%~ > 0 ? 1 : 0) ~multi_match~ = 1 ~match_opcode~ = 58 ~opcode~ = 177 ~parameter1~ = ~%SPECIFIC_NISHRUU_HAKEASHAR%~ ~parameter2~ = 6 ~special~ = 0 STR_VAR ~resource~ = ~destself~ ~insert~ = ~below~ END // Use EFF file (SPECIFIC.IDS)
+					END
+				END
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END*/
+
+	// They should be flagged as `GENERAL=MONSTER` / `RACE=MIST` / `CLASS=MIST` on all games
+	// They are supposed to be able to cast no spell
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING
+			"nishrusu.cre" "override" // Nishruu
+			"haksu.cre" "override" // Hakeashar
+			WRITE_BYTE 0x271 IDS_OF_SYMBOL ("GENERAL" "MONSTER") // was GIANTHUMANOID on bgee
+			WRITE_BYTE 0x272 IDS_OF_SYMBOL ("RACE" "MIST") // was OGRE on bgee
+			WRITE_BYTE 0x273 IDS_OF_SYMBOL ("CLASS" "MIST") // was OGRE_MAGE on bg(2)ee
+			WRITE_BYTE 0x274 "%SPECIFIC_NISHRUU_HAKEASHAR%"
+			REMOVE_KNOWN_SPELLS
+			REMOVE_MEMORIZED_SPELLS
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	// Their attack should ignore all AC modifiers
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "nishruu.itm" "override"
+			/* Ability */
+			LPF "ALTER_ITEM_HEADER"
+			INT_VAR
+				"damage_type" = 0 // None
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	// The Nishruu should be fully immune to Poison
+	// The Hakeashar should be fully immune to Poison and see invisible creatures
+	// Make sure the Nishruu uses the NISHRUU animation on all games
+	// Make sure the Hakeashar uses the HAKEASHAR animation on all games
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "nishrusu.cre" "override" // Nishruu
+			WRITE_LONG 0x28 IDS_OF_SYMBOL ("ANIMATE" "NISHRUU") // was MIST_CREATURE on bg(2ee)
+			LAUNCH_PATCH_FUNCTION ~CLONE_EFFECT~ INT_VAR ~multi_match~ = 1 ~match_opcode~ = 101 ~match_parameter2~ = 25 ~opcode~ = 173 ~parameter1~ = 100 ~parameter2~ = 0 STR_VAR ~resource~ = ~~ END // Poison resistance (set to 100)
+			PATCH_IF "%game_is_iwdee%" BEGIN
+				LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 233 END // delete unused weapon proficiencies
+			END
+			LPF ~GET_CRE_EFFECTS~ RET_ARRAY "cre_effects" END
+		BUT_ONLY_IF_IT_CHANGES
+		WITH_SCOPE BEGIN
+			COPY_EXISTING "haksu.cre" "override" // Hakeashar
+				WRITE_LONG 0x28 IDS_OF_SYMBOL ("ANIMATE" "HAKEASHAR") // was MIST_CREATURE on bg(2ee)
+				PATCH_IF "%game_is_iwdee%" BEGIN
+					LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 233 END // delete unused weapon proficiencies
+				END
+				PHP_EACH "cre_effects" AS "fx_attributes" => "irrelevant" BEGIN
+					LPF "ADD_CRE_EFFECT"
+					INT_VAR
+						"opcode" = "%fx_attributes_0%"
+						"target" = 1 // self
+						"parameter1" = "%fx_attributes_1%"
+						"parameter2" = "%fx_attributes_2%"
+						"timing" = 9 // instant/permanent
+						"special" = "%fx_attributes_4%"
+					STR_VAR
+						"resource" = "%fx_attributes_3%"
+					END
+				END
+			BUT_ONLY_IF_IT_CHANGES
+		END
+	END
+END
+
+/////////////////////////////////////////////////////////////////
+/*
+
+Collect all CRE effects into an array
+
+*/
+//////////////////////////////////////////////////////////////////
+
+DEFINE_PATCH_FUNCTION "GET_CRE_EFFECTS"
+RET_ARRAY
+	"cre_effects"
+BEGIN
+	// Initialize
+	PATCH_CLEAR_ARRAY "cre_effects"
+	LPF ~FJ_CRE_VALIDITY~ END // make sure it uses EFFv2 effects
+	// Main
+	GET_OFFSET_ARRAY "fx_array" CRE_V10_EFFECTS
+	PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+		READ_LONG ("%fx_off%" + 0x8) "fx_opcode"
+		READ_SLONG ("%fx_off%" + 0x14) "fx_parameter1"
+		READ_SLONG ("%fx_off%" + 0x18) "fx_parameter2"
+		READ_ASCII ("%fx_off%" + 0x28) "fx_resref"
+		READ_SLONG ("%fx_off%" + 0x40) "fx_special"
+		TEXT_SPRINT $"cre_effects"("%fx_opcode%" "%fx_parameter1%" "%fx_parameter2%" "%fx_resref%" "%fx_special%" "%fx_ind%") "irrelevant"
+	END
+END


### PR DESCRIPTION
**Summon Nishruu / Hakeashar**:
- their attack (`nishrusu.itm`) should ignore all `AC` modifiers
  - previously, since it was using `damage_type=piercing`, the Nishruu (`THAC0=11`) would need to roll a Critical Hit in order to hit `AC -9 vs. piercing` attacks targets. A similar argument holds for the Hakeashar
    - this is certainly unintended since they don't actually deal piercing damage
- they should be vulnerable to Dispel/Remove Magic
- they should be flagged as `GENERAL=MONSTER` / `RACE=MIST` / `CLASS=MIST` on all games
- make sure the Nishruu has `100%` Poison resistance
- the Hakeashar should have the same passive traits as the Nishruu
  - i.e., it should be immune to Poison and see invisible creatures
- the Nishruu should use the `NISHRUU` animation on all games
- the Hakeashar should use the `HAKEASHAR` animation on all games
- removed unused (and unintended) spell setup