### PR TITLE
Fix Mendas's dialogue triggering the wrong spell.

### DIFF
--- a/eefixpack/files/d/bgee_core_fixes.d
+++ b/eefixpack/files/d/bgee_core_fixes.d
@@ -41,3 +41,7 @@ END
 // tbd, cam
 // perdue says he's giving you 50 gold, but only delivers if you actually accepted the quest
 REPLACE_ACTION_TEXT perdue ~GivePartyGoldGlobal("PerduePayment","GLOBAL")~ ~GivePartyGold(50)~
+
+// tbd, graion
+// mendas's dialogue triggers the wrong spell
+REPLACE_ACTION_TEXT ~menda4~ ~ActionOverride("Baresh",ApplySpell(Myself,BERESH_CHANGE))~ ~ActionOverride("Baresh",ApplySpellRES("ohwi924",Myself))~


### PR DESCRIPTION
At one point Baresh and Kaishas were migrated over from SPWI924/925 to
OHWI924/925, but this one case was overlooked back then.