### PR TITLE
[bg] Shocking Grasp

### DIFF
--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -629,9 +629,9 @@ END
 luke
 **Shocking Grasp**
 - Should not interact with level-based spell protections
+- Secondary type should be `COMBINATION`
 - Delete expiry sound since the spell can end prematurely
-- It now casts a `SPL` file that scales with level (up to `20`)
-  - (instead of using `20` different `ITM` files)
+- Make sure `Range: Touch`
 */
 WITH_SCOPE BEGIN
   INCLUDE "eefixpack/files/tph/luke/shocking_grasp.tph"

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -913,9 +913,9 @@ END
 luke
 **Shocking Grasp**
 - Should not interact with level-based spell protections
+- Secondary type should be `COMBINATION`
 - Delete expiry sound since the spell can end prematurely
-- It now casts a `SPL` file that scales with level (up to `20`)
-  - (instead of using `20` different `ITM` files)
+- Make sure `Range: Touch`
 */
 WITH_SCOPE BEGIN
   INCLUDE "eefixpack/files/tph/luke/shocking_grasp.tph"

--- a/eefixpack/files/tph/luke/magical_weapon_slot.tph
+++ b/eefixpack/files/tph/luke/magical_weapon_slot.tph
@@ -93,70 +93,67 @@ BEGIN
 	END
 	// Main
 	WITH_SCOPE BEGIN
-		COPY_EXISTING
-			~sgrasp.itm~ ~override~ // Shocking Grasp
-			~bclaw.itm~ ~override~ // Beast Claw
-			~seriuos.itm~ ~override~ // Cause Serious Wounds
-			~critical.itm~ ~override~ // Cause Critical Wounds
-			~slaylive.itm~ ~override~ // Slay Living
-			~harm.itm~ ~override~ // Harm
-			~ctouch.itm~ ~override~ // Chill Touch (iwd)
-			~chillt.itm~ ~override~ // Chill Touch (bg)
-			~ghoult.itm~ ~override~ // Ghoul Touch
-			~ltouch.itm~ ~override~ // Lich Touch
-			~ibody.itm~ ~override~ // Iron Body
+		COPY_EXISTING_REGEXP
+			~sgrasp[0-9][0-9]\.itm~ ~override~ // Shocking Grasp (bg)
+			~bclaw\.itm~ ~override~ // Beast Claw
+			~seriuos\.itm~ ~override~ // Cause Serious Wounds
+			~critical\.itm~ ~override~ // Cause Critical Wounds
+			~slaylive\.itm~ ~override~ // Slay Living
+			~harm\.itm~ ~override~ // Harm
+			~ctouch\.itm~ ~override~ // Chill Touch (iwd)
+			~chillt\.itm~ ~override~ // Chill Touch (bg)
+			~ghoult\.itm~ ~override~ // Ghoul Touch
+			~ltouch\.itm~ ~override~ // Lich Touch
+			~ibody\.itm~ ~override~ // Iron Body
 			/* Polymorph Self */
-			~plybear1.itm~ ~override~ // Shapeshift: Brown Bear
-			~plybear2.itm~ ~override~ // Shapeshift: Black Bear
-			~plymstar.itm~ ~override~ // Shapeshift: Ogre
-			~plyspid.itm~ ~override~ // Shapeshift: Spider
-			~plywolf1.itm~ ~override~ // Shapeshift: Wolf
-			~cdpolybb.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
-			~cdpolypb.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
-			~cdpolyww.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
+			~plybear1\.itm~ ~override~ // Shapeshift: Brown Bear
+			~plybear2\.itm~ ~override~ // Shapeshift: Black Bear
+			~plymstar\.itm~ ~override~ // Shapeshift: Ogre
+			~plyspid\.itm~ ~override~ // Shapeshift: Spider
+			~plywolf1\.itm~ ~override~ // Shapeshift: Wolf
+			~cdpolybb\.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
+			~cdpolypb\.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
+			~cdpolyww\.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
 			/* Shapechange */
-			~cdmindfl.itm~ ~override~ // Shapechange: Mind Flayer
-			~cdgoliro.itm~ ~override~ // Shapechange: Iron Golem
-			~trollall.itm~ ~override~ // Shapechange: Giant Troll
-			~wolfgr.itm~ ~override~ // Shapechange: Greater Wolfwere
-			~firern.itm~ ~override~ // Shapechange: Fire Elemental
-			~earthrn.itm~ ~override~ // Shapechange: Earth Elemental
-			~cdshwele.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
+			~cdmindfl\.itm~ ~override~ // Shapechange: Mind Flayer
+			~cdgoliro\.itm~ ~override~ // Shapechange: Iron Golem
+			~trollall\.itm~ ~override~ // Shapechange: Giant Troll
+			~wolfgr\.itm~ ~override~ // Shapechange: Greater Wolfwere
+			~firern\.itm~ ~override~ // Shapechange: Fire Elemental
+			~earthrn\.itm~ ~override~ // Shapechange: Earth Elemental
+			~cdshwele\.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
 			/* Unkitted Druid */
-			~brbrp.itm~ ~override~ // Shapeshift: Brown Bear (bg)
-			~wolfm.itm~ ~override~ // Shapeshift: Wolf (bg)
-			~brblp.itm~ ~override~ // Shapeshift: Black Bear (bg)
-			~plypbear.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
-			~plywwolf.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
-			~plybeetl.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
-			~felem.itm~ ~override~ // Shapeshift: Fire Elemental (iwd)
-			~eelem.itm~ ~override~ // Shapeshift: Earth Elemental (iwd)
-			~welem.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
+			~brbrp\.itm~ ~override~ // Shapeshift: Brown Bear (bg)
+			~wolfm\.itm~ ~override~ // Shapeshift: Wolf (bg)
+			~brblp\.itm~ ~override~ // Shapeshift: Black Bear (bg)
+			~plypbear\.itm~ ~override~ // Shapeshift: Polar Bear (iwd)
+			~plywwolf\.itm~ ~override~ // Shapeshift: Winter Wolf (iwd)
+			~plybeetl\.itm~ ~override~ // Shapeshift: Boring Beetle (iwd)
+			~felem\.itm~ ~override~ // Shapeshift: Fire Elemental (iwd)
+			~eelem\.itm~ ~override~ // Shapeshift: Earth Elemental (iwd)
+			~welem\.itm~ ~override~ // Shapeshift: Water Elemental (iwd)
 			/* Avenger (Druid) */
-			~plyspid2.itm~ ~override~ // Shapeshift: Sword Spider
-			~plywyvrn.itm~ ~override~ // Shapeshift: Baby Wyvern
-			~plybass.itm~ ~override~ // Shapeshift: Lesser Basilisk (old, unused)
+			~plyspid2\.itm~ ~override~ // Shapeshift: Sword Spider
+			~plywyvrn\.itm~ ~override~ // Shapeshift: Baby Wyvern
+			~plybass\.itm~ ~override~ // Shapeshift: Lesser Basilisk (old, unused)
 			/* Shapeshifter (Druid) */
-			~brbrp1.itm~ ~override~ // Shapeshift: Werewolf (bg)
-			~brbrp2.itm~ ~override~ // Shapeshift: Greater Werewolf (bg)
-			~cdbrbrp.itm~ ~override~ // Shapeshift: Werewolf (bg)
-			~cdbrbrp2.itm~ ~override~ // Shapeshift: Greater Werewolf (bg2)
-			~werewfl1.itm~ ~override~ // Shapeshift: Werewolf (bg)
-			~werewfl2.itm~ ~override~ // Shapeshift: Greater Werewolf (iwd)
+			~brbrp1\.itm~ ~override~ // Shapeshift: Werewolf (bg)
+			~brbrp2\.itm~ ~override~ // Shapeshift: Greater Werewolf (bg)
+			~cdbrbrp\.itm~ ~override~ // Shapeshift: Werewolf (bg2)
+			~cdbrbrp2\.itm~ ~override~ // Shapeshift: Greater Werewolf (bg2)
+			~werewfl1\.itm~ ~override~ // Shapeshift: Werewolf (iwd)
+			~werewfl2\.itm~ ~override~ // Shapeshift: Greater Werewolf (iwd)
 			/* Other */
-			~squirp.itm~ ~override~ // Polymorph Other
-			~wswolf.itm~ ~override~ // Polymorph Other (wild surge)
-			~cdwolfm.itm~ ~override~ // Relair's Mistake
-			~polyrat.itm~ ~override~ // Cloak of the Sewers (Rat)
-			~plytroll.itm~ ~override~ // Cloak of the Sewers (Troll)
-			~drufir.itm~ ~override~ // Fire Elemental Transformation
-			~druear.itm~ ~override~ // Earth Elemental Transformation
-			~slayerw1.itm~ ~override~ // Slayer Change
-			~slayerw2.itm~ ~override~ // Slayer Change
-			~slayerw3.itm~ ~override~ // Slayer Change
-			~slayerw4.itm~ ~override~ // Slayer Change
+			~squirp\.itm~ ~override~ // Polymorph Other
+			~wswolf\.itm~ ~override~ // Polymorph Other (wild surge)
+			~cdwolfm\.itm~ ~override~ // Relair's Mistake
+			~polyrat\.itm~ ~override~ // Cloak of the Sewers (Rat)
+			~plytroll\.itm~ ~override~ // Cloak of the Sewers (Troll)
+			~drufir\.itm~ ~override~ // Fire Elemental Transformation
+			~druear\.itm~ ~override~ // Earth Elemental Transformation
+			~slayerw[1-4]\.itm~ ~override~ // Slayer Change
 			PATCH_MATCH "%DEST_RES%" WITH
-				~bclaw~ ~serious~ ~critical~ ~slaylive~ ~harm~ ~ctouch~ ~chillt~ ~ghoult~ ~ltouch~ ~ibody~ BEGIN
+				~sgrasp[0-9][0-9]~ ~bclaw~ ~serious~ ~critical~ ~slaylive~ ~harm~ ~ctouch~ ~chillt~ ~ghoult~ ~ltouch~ ~ibody~ BEGIN
 					WRITE_LONG 0x18 (THIS BAND BNOT IDS_OF_SYMBOL ("ITEMFLAG" "DISABLE_OFFHAND") BOR IDS_OF_SYMBOL ("ITEMFLAG" "LEFTHANDED")) // make sure to completely disable off-hand (including passive bonuses / maluses)
 					LAUNCH_PATCH_FUNCTION "ADD_ITEM_EQEFFECT"
 					INT_VAR

--- a/eefixpack/files/tph/luke/shocking_grasp.tph
+++ b/eefixpack/files/tph/luke/shocking_grasp.tph
@@ -1,17 +1,17 @@
 DEFINE_ACTION_FUNCTION "WIZARD_SHOCKING_GRASP"
 BEGIN
-	// Let us use a unique ITM file for all character levels
+	// Let us use a unique ITM file for all character levels => BAD when the spell is cast from scroll!!!
 	WITH_SCOPE BEGIN
 		COPY_EXISTING "%WIZARD_SHOCKING_GRASP%.spl" "override" // spwi115
 			/* Header */
 			WRITE_BYTE 0x27 12 // COMBATPROTECTIONS => COMBINATION
 			/* Feature blocks */
-			LPF "ALTER_EFFECT"
+			/*LPF "ALTER_EFFECT"
 			INT_VAR
 				"match_opcode" = 111 // Create weapon
 			STR_VAR
 				"resource" = "SGRASP"
-			END
+			END*/
 			// Delete expiry sound since the spell can end prematurely
 			LPF "DELETE_EFFECT"
 			INT_VAR
@@ -22,10 +22,10 @@ BEGIN
 	END
 	// ITM file
 	WITH_SCOPE BEGIN
-		COPY_EXISTING "sgrasp.itm" "override"
+		COPY_EXISTING_REGEXP "sgrasp[0-9][0-9]\.itm" "override"
 			/* Header */
-			WRITE_LONG 0x18 THIS BOR IDS_OF_SYMBOL ("itemflag" "SILVER") BOR IDS_OF_SYMBOL ("itemflag" "COLDIRON")
-			WRITE_ASCII 0x3A "ISGRASP" #8 // Inventory icon
+			//WRITE_LONG 0x18 THIS BOR IDS_OF_SYMBOL ("itemflag" "SILVER") BOR IDS_OF_SYMBOL ("itemflag" "COLDIRON")
+			//WRITE_ASCII 0x3A "ISGRASP" #8 // Inventory icon
 			/* Extended header */
 			LPF "ALTER_ITEM_HEADER"
 			INT_VAR
@@ -34,7 +34,7 @@ BEGIN
 				"icon" = "ISGRASP"
 			END
 			/* Feature blocks */
-			LPF "DELETE_EFFECT" END // delete current content
+			/*LPF "DELETE_EFFECT" END // delete current content
 			LPF "ADD_ITEM_EFFECT"
 			INT_VAR
 				"type" = 1 // Melee headers
@@ -44,11 +44,12 @@ BEGIN
 				"timing" = 1
 			STR_VAR
 				"resource" = "%DEST_RES%"
-			END
+			END*/
+			LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "power" = 0 END
 		BUT_ONLY_IF_IT_CHANGES
 	END
 	// Auxiliary subspell
-	WITH_SCOPE BEGIN
+	/*WITH_SCOPE BEGIN
 		CREATE "SPL" "sgrasp"
 			WRITE_LONG NAME1 ~-1~
 			WRITE_LONG NAME2 ~-1~
@@ -64,14 +65,14 @@ BEGIN
 			WRITE_SHORT 0x68 1 // # abilities
 			WRITE_LONG 0x6a 0x9a // Effects offset
 			INSERT_BYTES 0x72 0x28
-			/* Extended Header */
+			// Extended Header
 			WRITE_ASCIIE 0x76 ~%WIZARD_SHOCKING_GRASP%B~ #8 // Icon
 			WRITE_SHORT 0x80 32767 // Range
 			WRITE_SHORT 0x82 1 // Minimum level
 			WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
 			// Extend up to character level 20
 			LPF "CD_EXTEND-O-MATIC" END
-			/* Feature blocks */
+			// Feature blocks
 			// "... an electrical charge will deal 1d8 points of damage plus 1 per level of the caster..."
 			PATCH_WITH_SCOPE BEGIN
 				FOR ("i" = 1 ; "%i%" <= SHORT_AT 0x68 ; "i" += 1) BEGIN
@@ -95,5 +96,5 @@ BEGIN
 				"parameter2" = 6 // Alteration water
 				"timing" = 1
 			END
-	END
+	END*/
 END


### PR DESCRIPTION
Reverting back my previous fix since it may cause issues when the spell is cast from scroll.

In particular, all those 20 `itm` files (`sgrasp01 ... sgrasp20`) are needed to properly set the damage output. If you replace them with a single scalable `spl` file, then when Shocking Grasp is cast from scroll, spell duration will be set correctly, but its damage will be based on caster's (wizard) level (which might differ from the level specified by the scroll).