### PR TITLE
GT_7EYES-O-MATIC

### DIFF
--- a/eefixpack/files/lib/gt_7eyes-o-matic.tph
+++ b/eefixpack/files/lib/gt_7eyes-o-matic.tph
@@ -1,0 +1,901 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+
+See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+This is basically the dynamic (softcoded) version of "eefixpack\files\lib\gt_7eyes.tph"
+
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_ACTION_FUNCTION "GT_7EYES-O-MATIC"
+BEGIN
+	CLEAR_ARRAYS
+	ACTION_DEFINE_ARRAY "digit" BEGIN "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" END
+	ACTION_DEFINE_ARRAY "letter" BEGIN "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" END
+	// Main
+	COPY_EXISTING_REGEXP "^.+\.\(itm\|spl\)$" "override"
+		PATCH_MATCH "%DEST_EXT%" WITH
+			"ITM" BEGIN
+				GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
+			END
+			"SPL" BEGIN
+				GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
+			END
+			DEFAULT
+				PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+		END
+		// Opcodes to check (based on IWD:EE "7eyes.2da"): Berserk, Charm creature, Damage, Panic, Poison, Silence, Stun, Blindness, Feeblemindedness, Deafness, Paralyze, Confusion, Petrification, Hold creature, Power word: stun
+		PATCH_FOR_EACH "effectID" IN 3 5 24 25 38 45 74 76 80 109 128 134 175 210 12 BEGIN
+			PATCH_IF ("%effectID%" != 12) OR ("%DEST_EXT%" STRING_EQUAL_CASE "spl") BEGIN // the Damage opcode (0xC) usually has no ancillary effects (since they are defined in "dmgtypes.2da"). As a result, skip "*.itm" files ...
+				PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+					// For each ability ...
+					PATCH_WITH_SCOPE BEGIN
+						GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+						PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+							// Take note of current effect's attributes
+							READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
+							READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
+							READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
+							READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
+							READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
+							READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
+							READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
+							READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
+							READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
+							READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
+							READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
+							READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
+							READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
+							READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
+							READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
+							READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
+							// 
+							PATCH_IF ("%ITMSPL_effect_opcode%" == "%effectID%") BEGIN
+								PATCH_MATCH "%effectID%" WITH
+									3 BEGIN // Berserker
+										TEXT_SPRINT "effectName" "Berserker"
+									END
+									5 BEGIN // Charm creature
+										TEXT_SPRINT "effectName" "CharmCreature"
+									END
+									12 BEGIN // Damage
+										TEXT_SPRINT "effectName" "Damage"
+									END
+									24 BEGIN // Panic
+										TEXT_SPRINT "effectName" "Panic"
+									END
+									25 BEGIN // Poison
+										TEXT_SPRINT "effectName" "Poison"
+									END
+									38 BEGIN // Silence
+										TEXT_SPRINT "effectName" "Silence"
+									END
+									45 BEGIN // Stun
+										TEXT_SPRINT "effectName" "Stun"
+									END
+									74 BEGIN // Blindness
+										TEXT_SPRINT "effectName" "Blindness"
+									END
+									76 BEGIN // Feeblemindedness
+										TEXT_SPRINT "effectName" "Feeblemindedness"
+									END
+									80 BEGIN // Deafness
+										TEXT_SPRINT "effectName" "Deafness"
+									END
+									109 BEGIN // Paralyze
+										TEXT_SPRINT "effectName" "Paralyze"
+									END
+									128 BEGIN // Confusion
+										TEXT_SPRINT "effectName" "Confusion"
+									END
+									134 BEGIN // Petrification
+										TEXT_SPRINT "effectName" "Petrification"
+									END
+									175 BEGIN // Hold creature
+										TEXT_SPRINT "effectName" "HoldCreature"
+									END
+									210 BEGIN // Power word, Stun
+										TEXT_SPRINT "effectName" "PowerWordStun"
+									END
+									DEFAULT
+								END
+								PATCH_MATCH "%effectID%" WITH
+									12 BEGIN // Damage
+										// Do nothing if "%effectID%" is already last in the current effects stack
+										PATCH_IF ("%fx_ind%" < SHORT_AT ("%ab_off%" + 0x1E) - 1) BEGIN // NB.: same for "*.spl" and "*.itm"
+											PATCH_MATCH (SHORT_AT ("%fx_off%" + 0xA) << 16) WITH // Damage type
+												IDS_OF_SYMBOL ("DMGTYPE" "MISSILE") BEGIN // EYESWORD
+													TEXT_SPRINT "effectName" "%effectName%/Missile"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "CRUSHING") BEGIN
+													TEXT_SPRINT "effectName" "%effectName%/Crushing" // EYESWORD
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "PIERCING") BEGIN
+													TEXT_SPRINT "effectName" "%effectName%/Piercing" // EYESWORD
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "SLASHING") BEGIN // EYESWORD
+													TEXT_SPRINT "effectName" "%effectName%/Slashing"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "FIRE") BEGIN // EYEMAGE
+													TEXT_SPRINT "effectName" "%effectName%/Fire"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "COLD") BEGIN // EYEMAGE
+													TEXT_SPRINT "effectName" "%effectName%/Cold"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "ACID") BEGIN // EYEMAGE
+													TEXT_SPRINT "effectName" "%effectName%/Acid"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "ELECTRICITY") BEGIN // EYEMAGE
+													TEXT_SPRINT "effectName" "%effectName%/Electricity"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												IDS_OF_SYMBOL ("DMGTYPE" "POISON") BEGIN // EYEVENOM
+													TEXT_SPRINT "effectName" "%effectName%/Poison"
+													DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+												END
+												DEFAULT
+											END
+										END
+									END
+									DEFAULT
+										// Do nothing if "%effectID%" is already last in the current effects stack
+										PATCH_IF ("%fx_ind%" < SHORT_AT ("%ab_off%" + 0x1E) - 1) BEGIN // NB.: same for "*.spl" and "*.itm"
+											DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+												"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+											END
+											WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+										END
+								END
+							END
+						END
+						// For each "%effectID%" found, get its ancillary effects (if any)
+						PHP_EACH "fx_match" AS "fx_match_attribute" => "" BEGIN
+							PATCH_WITH_SCOPE BEGIN
+								SET "non-cosmetic_effects" = 0 // Suppose there are no non-cosmetic effects
+								GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+								PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+									// Take note of current effect's attributes
+									READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
+									READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
+									READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
+									READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
+									READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
+									READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
+									READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
+									READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
+									READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
+									READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
+									READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
+									READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
+									READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
+									READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
+									READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
+									READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
+									// 
+									PATCH_MATCH "%ITMSPL_effect_opcode%" WITH
+										999 BEGIN END // skip mark
+										"%effectID%" WHEN ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") AND ("%ITMSPL_effect_parameter1%" == "%fx_match_attribute_3%") AND ("%ITMSPL_effect_parameter2%" == "%fx_match_attribute_4%") BEGIN END // skip subspell in case of multiple "%effectID%" effects of the same type (see f.i. "spwi211.spl", "spwi508.spl", ...)
+										7 8 9 41 50 51 52 61 215 BEGIN // Visual effects
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																	PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																				DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																					"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																				END
+																				WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										139 BEGIN // Display string
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																	PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																				// WeiDU's GET_STRREF is language-dependant, so we need to fetch the corresponding string from the english version of "dialog.tlk"
+																				LPF "GT_7EYES-O-MATIC#GET_STRREF" RET "strref" END
+																				PATCH_MATCH "%effectID%" WITH
+																					3 WHEN ("%strref%" STR_EQ "Berserk") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					5 WHEN ("%sreref%" STR_EQ "Charmed") OR ("%strref%" STR_EQ "Dominated") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					12 WHEN ("%strref%" STR_EQ "Bleeding") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					24 WHEN ("%strref%" STR_EQ "Panic") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					25 WHEN ("%strref%" STR_EQ "Poison") OR ("%strref%" STR_EQ "Poisoned") OR ("%strref%" STR_EQ "Bleeding") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					38 WHEN ("%strref%" STR_EQ "Silence") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					45 210 WHEN ("%strref%" STR_EQ "Stun") OR ("%strref%" STR_EQ "Stunned") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					74 WHEN ("%strref%" STR_EQ "Blinded") OR ("%strref%" STR_EQ "Blindness") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					76 WHEN ("%strref%" STR_EQ "Mind Locked Away") OR ("%strref%" STR_EQ "Feebleminded") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					80 WHEN ("%strref%" STR_EQ "Deafness") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					109 WHEN ("%strref%" STR_EQ "Webbed") OR ("%strref%" STR_EQ "Paralyzed") OR ("%strref%" STR_EQ "Held") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					128 WHEN ("%strref%" STR_EQ "Confused") OR ("%strref%" STR_EQ "Rigid Thinking") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					134 WHEN ("%strref%" STR_EQ "Petrification") OR ("%strref%" STR_EQ "Petrified") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					175 WHEN ("%strref%" STR_EQ "Held") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																					DEFAULT
+																						SET "non-cosmetic_effects" = 1
+																				END
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										141 BEGIN // Lighting effects
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																	PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																				DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																					"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																				END
+																				WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										142 BEGIN // Display portrait icon
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN // see f.i. "spwi211.spl"
+														PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+																	PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																		PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																			PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																				PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																					PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																						//READ_ASCII "%fx_off%" "portrait_icon_fx" (0x30)
+																						PATCH_MATCH "%effectID%" WITH
+																							3 WHEN ("%ITMSPL_effect_parameter2%" == 4) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							5 WHEN ("%ITMSPL_effect_parameter2%" == 0) OR ("%ITMSPL_effect_parameter2%" == 1) OR ("%ITMSPL_effect_parameter2%" == 43) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							12 WHEN ("%ITMSPL_effect_parameter2%" == 137) OR ("%ITMSPL_effect_parameter2%" == 102) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							24 WHEN ("%ITMSPL_effect_parameter2%" == 36) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							25 WHEN ("%ITMSPL_effect_parameter2%" == 6) OR ("%ITMSPL_effect_parameter2%" == 137) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							38 WHEN ("%ITMSPL_effect_parameter2%" == 34) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							45 210 WHEN ("%ITMSPL_effect_parameter2%" == 55) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							74 WHEN ("%ITMSPL_effect_parameter2%" == 8) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							76 WHEN ("%ITMSPL_effect_parameter2%" == 48) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							80 WHEN ("%ITMSPL_effect_parameter2%" == 112) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							109 WHEN ("%ITMSPL_effect_parameter2%" == 13) OR ("%ITMSPL_effect_parameter2%" == 129) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							128 WHEN ("%ITMSPL_effect_parameter2%" == 2) OR ("%ITMSPL_effect_parameter2%" == 3) OR ("%ITMSPL_effect_parameter2%" == 47) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							134 WHEN !(GAME_IS "iwdee") OR ("%ITMSPL_effect_parameter2%" == 171) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							175 WHEN ("%ITMSPL_effect_parameter2%" == 13) BEGIN
+																								DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																									"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																								END
+																								WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																							END
+																							DEFAULT
+																								SET "non-cosmetic_effects" = 1
+																						END
+																					END
+																				END
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										12 WHEN ("%effectID%" == 25) AND ((SHORT_AT ("%fx_off%" + 0xA) << 16) == IDS_OF_SYMBOL ("DMGTYPE" "POISON")) BEGIN // Damage type: Poison
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																END
+																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+															END
+														END
+													END
+												END
+											END
+										END
+										25 WHEN ("%effectID%" == 12) AND ("%effectName%" STR_EQ "Damage/Poison") BEGIN // Poison
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																END
+																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+															END
+														END
+													END
+												END
+											END
+										END
+										54 WHEN ("%effectID%" == 74) OR ("%effectID%" == 24) BEGIN // Base THAC0 bonus (include THAC0 penalty as part of fear - see f.i. "spin895.spl")
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+																	PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																				PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																					PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																				END
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										157 WHEN ("%effectID%" == 109) BEGIN // Web overlay
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+																	PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																				PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																					PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																						DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																							"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																						END
+																						WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					END
+																				END
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										174 WHEN ("%ITMSPL_effect_timing%" == 1) BEGIN // Play sound
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																	PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																		PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																				DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																					"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																				END
+																				WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										174 WHEN ("%ITMSPL_effect_timing%" == 4) BEGIN // Play sound (expiry sound)
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+																	PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																		PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																			PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																				PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																					//READ_ASCII "%fx_off%" "play_sound_fx" (0x30)
+																					DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																						"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																					END
+																					WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																					WRITE_LONG ("%fx_off%" + 0x2C) 998 // mark it for later detection
+																				END
+																			END
+																		END
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										321 WHEN ("%effectID%" != 12) AND ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%DEST_RES%") BEGIN // Remove effects by resource
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+															PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+																PATCH_IF ("%effectID%" == 12) OR ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+																	DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																		"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																	END
+																	WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+										206 318 324 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%DEST_RES%") BEGIN END
+										DEFAULT
+											PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+												SET "non-cosmetic_effects" = 1
+												//PATCH_PRINT "non-cosmetic_effects => %ITMSPL_effect_opcode%, resource => %ITMSPL_effect_resource%"
+											END
+									END
+								END
+								// If there are non-cosmetic effects (OR we're dealing with an "*.itm" file), patch accordingly
+								PATCH_IF ("%non-cosmetic_effects%") OR ("%DEST_EXT%" STR_EQ "ITM") BEGIN
+									//PATCH_PRINT "%DEST_FILE% needs subspell ..."
+									//PATCH_PRINT "current match: %effectID% (%effectName%) non-cosmetic_effects=%non-cosmetic_effects%"
+									PATCH_IF ("%non-cosmetic_effects%") BEGIN
+										PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+											//PATCH_PRINT "Restoring ancillary effect #%fx_ancillary_attribute_0% ..."
+											PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+												7 8 9 41 50 51 52 61 141 174 215 321 BEGIN // if there are non-cosmetic effects, then keep the cosmetic ones on the parent file ...
+													LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "silent" = 1 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 "opcode" = "%fx_ancillary_attribute_0%" END
+												END
+												DEFAULT
+													// op139, op142, ...
+													LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 END
+											END
+										END
+									END ELSE BEGIN
+										LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END
+									END
+									// Generate a filename for the child "*.spl" file
+									LPF "GT_7EYES-O-MATIC#GET_UNIQUE_FILE_NAME" RET "filename" END
+									// Keep track of some parent file data
+									PATCH_MATCH "%DEST_EXT%" WITH
+										"SPL" BEGIN
+											SET "parent_spell_type" = SHORT_AT 0x1C
+											SET "parent_primary_type" = BYTE_AT 0x25
+											SET "parent_secondary_type" = BYTE_AT 0x27
+											READ_ASCII 0x3A "parent_icon_c"
+											READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
+											SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
+										END
+										"ITM" BEGIN
+											SET "parent_spell_type" = 4 // Innate
+											READ_ASCII 0x3A "parent_icon_c"
+											READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
+											SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
+											SET "parent_primary_type" = BYTE_AT ("%ab_off%" + 0x17)
+											SET "parent_secondary_type" = BYTE_AT ("%ab_off%" + 0x19)
+										END
+										DEFAULT
+											PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+									END
+									// Get current projectile type (so as to properly set the 'power' attribute)
+									LPF "GT_7EYES-O-MATIC#GET_PROJECTILE_TYPE" RET "projectile_type" END
+									// Create subspell
+									INNER_ACTION BEGIN
+										WITH_SCOPE BEGIN
+											CREATE "SPL" "%filename%"
+											COPY_EXISTING "%filename%.spl" "override"
+												/* Header */
+												WRITE_LONG NAME1 "-1"
+												WRITE_LONG NAME2 "-1"
+												WRITE_SHORT 0x1C "%parent_spell_type%"
+												WRITE_BYTE 0x25 "%parent_primary_type%"
+												WRITE_BYTE 0x27 "%parent_secondary_type%"
+												WRITE_LONG 0x34 1 // Spell level
+												WRITE_ASCII 0x3A "%parent_icon_c%"
+												WRITE_LONG UNIDENTIFIED_DESC "-1"
+												WRITE_LONG DESC "-1"
+												WRITE_LONG 0x64 0x72 // Extended Header offset
+												WRITE_SHORT 0x68 1 // Extended Header count
+												WRITE_LONG 0x6A 0x9A // Feature Block Table offset
+												INSERT_BYTES 0x72 0x28
+												/* Extended Header */
+												WRITE_BYTE 0x72 1 // Ability type
+												WRITE_SHORT 0x74 4 // Ability location: F13 (Special Ability)
+												WRITE_ASCII 0x76 ~%parent_icon_b%~ // Ability icon
+												WRITE_BYTE 0x7E "%parent_ability_target%" // Ability target
+												WRITE_SHORT 0x80 0x7FFF // Ability range
+												WRITE_SHORT 0x82 1 // Minimum level
+												WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
+											BUT_ONLY
+										END
+									END
+									// If we're dealing with op12 (0xC - Damage), then put Dicenumber / Dicesize / Savetype / Savebonus in the child "*.spl" file ...
+									PATCH_IF ("%effectID%" == 12) BEGIN // Damage
+										LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "header" = "%ab_ind%" "multi_match" = 1 "match_opcode" = 999 "opcode" = 146 "parameter1" = 0 "parameter2" = 1 "timing" = 1 "duration" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%filename%" END
+										INNER_ACTION BEGIN
+											WITH_SCOPE BEGIN
+												COPY_EXISTING "%filename%.spl" "override"
+													/* Feature blocks */
+													LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_match_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+													PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+														PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+															7 8 9 41 50 51 52 61 141 215 WHEN ("%non-cosmetic_effects%") BEGIN END
+															174 WHEN !(("%non-cosmetic_effects%") AND ("%fx_ancillary_attribute_5%" == 4)) BEGIN END // skip non-expiry sound effects
+															DEFAULT
+																PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+																	321 BEGIN
+																		LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = "%fx_ancillary_attribute_4%" "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+																	END
+																	DEFAULT
+																		LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = "%fx_ancillary_attribute_4%" "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+																END
+														END
+													END
+												BUT_ONLY_IF_IT_CHANGES
+											END
+										END
+									END ELSE BEGIN
+										// ... otherwise put Dicenumber / Dicesize / Savetype / Savebonus in the parent file
+										LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "header" = "%ab_ind%" "multi_match" = 1 "match_opcode" = 999 "opcode" = 146 "parameter1" = 0 "parameter2" = 1 "timing" = 1 "duration" = 0 "special" = 0 STR_VAR "resource" = "%filename%" END
+										INNER_ACTION BEGIN
+											WITH_SCOPE BEGIN
+												COPY_EXISTING "%filename%.spl" "override"
+													/* Feature blocks */
+													LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_match_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+													PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+														PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+															7 8 9 41 50 51 52 61 141 215 WHEN ("%non-cosmetic_effects%") BEGIN END
+															174 WHEN !(("%non-cosmetic_effects%") AND ("%fx_ancillary_attribute_5%" == 4)) BEGIN END // skip non-expiry sound effects
+															DEFAULT
+																PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+																	321 BEGIN
+																		LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%DEST_RES%" END
+																	END
+																	DEFAULT
+																		LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+																END
+														END
+													END
+												BUT_ONLY_IF_IT_CHANGES
+											END
+										END
+									END
+								END ELSE BEGIN
+									// Just reorder effect stack
+									LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 999 "multi_match" = 1 END // main effect ("%effectID%")
+									LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END // ancillary effects
+									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = "%fx_match_attribute_6%" "duration" = "%fx_match_attribute_7%" "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+									PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+										LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "header" = ("%ab_ind%" + 1) "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = "%fx_ancillary_attribute_2%" "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = "%fx_ancillary_attribute_6%" "duration" = "%fx_ancillary_attribute_7%" "probability1" = "%fx_ancillary_attribute_8%" "probability2" = "%fx_ancillary_attribute_9%" "dicenumber" = "%fx_ancillary_attribute_11%" "dicesize" = "%fx_ancillary_attribute_12%" "savingthrow" = "%fx_ancillary_attribute_13%" "savebonus" = "%fx_ancillary_attribute_14%" "special" = "%fx_ancillary_attribute_15%" STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+									END
+								END
+							END
+						END
+					END
+				END
+			END
+		END
+		// Remove delayed op174 effects (expiry sound) from parent file
+		PATCH_MATCH "%DEST_EXT%" WITH
+			"ITM" BEGIN
+				GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
+			END
+			"SPL" BEGIN
+				GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
+			END
+			DEFAULT
+				PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+		END
+		PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+				PATCH_MATCH SHORT_AT ("%fx_off%") WITH
+					174 WHEN SLONG_AT ("%fx_off%" + 0x2C) BEGIN
+						WRITE_SHORT "%fx_off%" 998
+					END
+					DEFAULT
+				END
+			END
+			LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "match_special" = 998 END // actual deletion
+		END
+	BUT_ONLY_IF_IT_CHANGES
+END
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+
+Helper functions
+
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_PATCH_FUNCTION "GT_7EYES-O-MATIC#GET_STRREF"
+RET
+	"strref"
+BEGIN
+	INNER_ACTION BEGIN
+		COPY - "lang\en_us\dialog.tlk" "override"
+			READ_LONG 0xE "base_off" // Offset to base data
+			READ_LONG (0x12 + 0x12 + ("%ITMSPL_effect_parameter1%" * 0x1A)) "off" // Relative offset of current string
+			READ_LONG (0x12 + 0x16 + ("%ITMSPL_effect_parameter1%" * 0x1A)) "length" // Length of this string
+			READ_ASCII ("%base_off%" + "%off%") "strref" ("%length%")
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END
+
+DEFINE_PATCH_FUNCTION "GT_7EYES-O-MATIC#GET_UNIQUE_FILE_NAME"
+RET
+	"filename"
+BEGIN
+	PATCH_IF (STRING_LENGTH "%DEST_RES%" <= 7) BEGIN
+		SNPRINT "-1" "last_character" "%DEST_RES%"
+		PATCH_MATCH "%last_character%" WITH
+			"[a-z]" BEGIN
+				SET "count" = 0
+				TEXT_SPRINT "suffix" $"digit"("%count%") // "0"
+				TEXT_SPRINT "filename" "%DEST_RES%%suffix%"
+				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
+					SET "count" += 1
+					TEXT_SPRINT "suffix" $"digit"("%count%")
+					TEXT_SPRINT "filename" "%DEST_RES%%suffix%"
+				END
+				PATCH_IF ("%count%" == 10) BEGIN
+					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_7Eyes_%effectName%_Ability#%ab_ind%_Effect%fx_match_attribute_16%_%DEST_FILE%" RET "filename" END
+				END
+			END
+			"[0-9]" BEGIN
+				SET "count" = 0
+				TEXT_SPRINT "suffix" $"letter"("%count%") // "a"
+				TEXT_SPRINT "filename" "%DEST_RES%%suffix%"
+				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
+					SET "count" += 1
+					TEXT_SPRINT "suffix" $"letter"("%count%")
+					TEXT_SPRINT "filename" "%DEST_RES%%suffix%"
+				END
+				PATCH_IF ("%count%" == 26) BEGIN
+					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_7Eyes_%effectName%_Ability#%ab_ind%_Effect%fx_match_attribute_16%_%DEST_FILE%" RET "filename" END
+				END
+			END
+			DEFAULT
+				LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_7Eyes_%effectName%_Ability#%ab_ind%_Effect%fx_match_attribute_16%_%DEST_FILE%" RET "filename" END
+		END
+	END ELSE BEGIN
+		LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_7Eyes_%effectName%_Ability#%ab_ind%_Effect%fx_match_attribute_16%_%DEST_FILE%" RET "filename" END
+	END
+	//
+	INNER_PATCH_SAVE "filename" "%filename%" BEGIN
+		REPLACE_TEXTUALLY EVALUATE_REGEXP "^__" "cd"
+	END
+	TO_LOWER "filename"
+END
+
+DEFINE_PATCH_FUNCTION "GT_7EYES-O-MATIC#GET_PROJECTILE_TYPE"
+RET
+	"projectile_type"
+BEGIN
+	SET "projectile_type" = 2 // Single target
+	PATCH_MATCH "%DEST_EXT%" WITH
+		"SPL" BEGIN
+			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x26) - 1)
+		END
+		"ITM" BEGIN
+			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x2A) - 1)
+		END
+		DEFAULT
+			PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+	END
+	INNER_PATCH_FILE "%projectile_res%.pro" BEGIN
+		READ_SHORT 0x8 "projectile_type"
+	END
+END

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -1586,3 +1586,13 @@ END
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // function for effect batches
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_bg2.tph~                 // use effect batches to remove vfx from effects which have been removed
+
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -1925,3 +1925,12 @@ INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // functio
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_bg.tph~                  // use effect batches to remove vfx from effects which have been removed
 
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -124,10 +124,10 @@ END
 luke
 "7eyes.2da" vs. SPL/ITM files
 */
-WITH_SCOPE BEGIN
+/*WITH_SCOPE BEGIN
   INCLUDE "eefixpack/files/tph/luke/7eyes/7eyes.tph"
   LAUNCH_ACTION_FUNCTION "7EYES" END
-END
+END*/
 
 /*
 luke
@@ -990,3 +990,13 @@ END
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // function for effect batches
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_iwd.tph~                 // use effect batches to remove vfx from effects which have been removed
+
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END

--- a/eefixpack/files/tph/luke/sunray.tph
+++ b/eefixpack/files/tph/luke/sunray.tph
@@ -80,7 +80,7 @@ BEGIN
 				/* Feature block(s) */
 				LPF "DELETE_EFFECT" END // delete current content
 				PATCH_WITH_SCOPE BEGIN
-					LPF "GET_FIRST_LEVEL_YOU_CAN_LEARN_XTH_LEVEL_SPELLS"
+					LPF "GET_FIRST_LEVEL_YOU_CAN_LEARN_X-TH_LEVEL_SPELLS"
 					INT_VAR
 						"spell_level" = LONG_AT 0x34
 					RET
@@ -158,7 +158,7 @@ BEGIN
 					"target" = 2 // Preset target
 					"parameter1" = "%game_is_bgee%" ? 31786 : 14674
 					"timing" = 1
-					"resist_dispel" = BIT1
+					"resist_dispel" = BIT0 + BIT1
 					"savingthrow" = BIT0 // Save vs. Spell
 				END
 			BUT_ONLY_IF_IT_CHANGES
@@ -316,7 +316,7 @@ Auxiliary function
 */
 //////////////////////////////////////////////////////////////////
 
-DEFINE_PATCH_FUNCTION "GET_FIRST_LEVEL_YOU_CAN_LEARN_XTH_LEVEL_SPELLS"
+DEFINE_PATCH_FUNCTION "GET_FIRST_LEVEL_YOU_CAN_LEARN_X-TH_LEVEL_SPELLS"
 INT_VAR
 	"spell_level" = "-1"
 RET


### PR DESCRIPTION
Tweaked version of my previous [pull request](https://github.com/Gibberlings3/EE_Fixpack/pull/23) about this topic (to tell the truth, it's also relevant for [this](https://www.gibberlings3.net/forums/topic/36020-curing-stuff-with-the-ee-fixpack-for-a-given-value-of-stuff/) and [this](https://www.gibberlings3.net/forums/topic/35616-effect-immunities-on-the-ee-engine-aka-taking-full-advantage-of-the-ee-fixpack/)).

Additionally, it now also expands to both BG:EE and BG2:EE for later compatibility with [IWDification](https://github.com/Gibberlings3/iwdification) and the Seven Eyes spell.