### PR TITLE
Opcode 39 overhaul

### DIFF
--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -138,6 +138,15 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "WING_BUFFET_VS_MR" END
 END
 
+/*
+luke
+**Op39 overhaul**
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAUNCH_ACTION_FUNCTION "OPCODE39_OVERHAUL" END
+END
+
 /////                                                  \\\\\
 ///// dialogue fixes                                   \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -1540,6 +1540,20 @@ COPY_EXISTING ~spin597.spl~  ~override~ // blue dragon breath needs additional f
   WRITE_LONG  0x34 1     // set spell level 1
   LPF ALTER_EFFECT INT_VAR power = 0 resist_dispel = 0 END
 
+/*
+luke
+**Earthquake**
+- Make sure all effects bypass Magic Resistance (since the spell is supposed to alter the environment instead of directly affecting the targeted creatures)
+*/
+WITH_SCOPE BEGIN
+  COPY_EXISTING
+    "ohbquake.spl" "override"
+    "spogre01.spl" "override"
+    "%CLERIC_EARTHQUAKE%.spl" "override"
+      LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "resist_dispel" = 0 END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// projectile fixes                                 \\\\\
 /////                                                  \\\\\
@@ -1586,3 +1600,23 @@ END
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // function for effect batches
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_bg2.tph~                 // use effect batches to remove vfx from effects which have been removed
+
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END
+
+/*
+luke
+**Opcode #39 overhaul**
+- See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAF "OPCODE39_OVERHAUL" END
+END

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -1019,8 +1019,10 @@ WITH_SCOPE BEGIN
 END
 
 // expiry sound has wrong duration  
+// [luke] Make sure all effects bypass Magic Resistance / are dispellable (so as to match op39, which bypasses MR and it's dispellable)
 COPY_EXISTING ~bdsleep.spl~  ~override~ // <Invalid Strref -1> - causes sleep - plays sound EFF_E05
   LPF ALTER_EFFECT INT_VAR match_duration = 30 duration = 300 END
+  LPF "ALTER_EFFECT" INT_VAR "resist_dispel" = (BIT0 + BIT1) END
   IF_EXISTS // sod asset
 
 // tbd, cam
@@ -1234,10 +1236,13 @@ WITH_SCOPE BEGIN
   BUT_ONLY_IF_IT_CHANGES
 END
 
-// luke
-// Stinking Cloud
-// 1) op39 can automatically display a portrait icon, there's no need to apply a separate op142 effect
-// 2) remove the "Bypass Mirror Image" flag (it's only relevant for opcode #12 and opcode #25)
+/*
+luke
+**Stinking Cloud**
+1. op39 can automatically display a portrait icon, there's no need to apply a separate op142 effect
+2. remove the "Bypass Mirror Image" flag (it's only relevant for opcode #12 and opcode #25)
+3. op324's resource field should not be empty
+*/
 WITH_SCOPE BEGIN
   COPY_EXISTING "%WIZARD_STINKING_CLOUD%.spl" "override" // spwi213
     PATCH_WITH_SCOPE BEGIN
@@ -1251,6 +1256,7 @@ WITH_SCOPE BEGIN
     END
     LAUNCH_PATCH_FUNCTION ~DELETE_EFFECT~ INT_VAR ~match_opcode~ = 142 END
     LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~match_opcode~ = 39 ~special~ = 126 END
+    LAUNCH_PATCH_FUNCTION ~ALTER_EFFECT~ INT_VAR ~match_opcode~ = 324 STR_VAR ~resource~ = "%DEST_RES%" END
   BUT_ONLY_IF_IT_CHANGES
 END
 
@@ -1850,6 +1856,20 @@ WITH_SCOPE BEGIN
   LAF ~NISHRUU_HAKEASHAR~ END
 END
 
+/*
+luke
+**Earthquake**
+- Make sure all effects bypass Magic Resistance (since the spell is supposed to alter the environment instead of directly affecting the targeted creatures)
+*/
+WITH_SCOPE BEGIN
+  COPY_EXISTING
+    "bpgiaqke.spl" "override"
+    "spogre01.spl" "override"
+    "%CLERIC_EARTHQUAKE%.spl" "override"
+      LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "resist_dispel" = 0 END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// projectile fixes                                 \\\\\
 /////                                                  \\\\\
@@ -1925,3 +1945,22 @@ INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // functio
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_bg.tph~                  // use effect batches to remove vfx from effects which have been removed
 
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END
+
+/*
+luke
+**Opcode #39 overhaul**
+- See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAF "OPCODE39_OVERHAUL" END
+END

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -227,6 +227,15 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "WING_BUFFET_VS_MR" END
 END
 
+/*
+luke
+**Op39 overhaul**
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAUNCH_ACTION_FUNCTION "OPCODE39_OVERHAUL" END
+END
+
 /////                                                  \\\\\
 ///// dialogue fixes                                   \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -924,6 +924,19 @@ END
 // don't play berserk damage warnings on non-party memebers; see also spin117[ab].eff
 INCLUDE ~eefixpack/files/tph/tbd_angry_noises.tph~
 
+/*
+luke
+**Earthquake**
+- Make sure all effects bypass Magic Resistance (since the spell is supposed to alter the environment instead of directly affecting the targeted creatures)
+*/
+WITH_SCOPE BEGIN
+  COPY_EXISTING
+    "spogre01.spl" "override"
+    "%CLERIC_EARTHQUAKE%.spl" "override"
+      LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "resist_dispel" = 0 END
+  BUT_ONLY_IF_IT_CHANGES
+END
+
 /////                                                  \\\\\
 ///// store fixes                                      \\\\\
 /////                                                  \\\\\
@@ -968,12 +981,27 @@ COPY_EXISTING ~worldmap.wmp~ ~override~ // inconsistent travel times
   END
   BUT_ONLY
 
-
+/////                                                  \\\\\
+///// projectile fixes                                 \\\\\
+/////                                                  \\\\\
 
 // tbd, cam
 // broken sound reference in lance of disruption projectile
 COPY_EXISTING ~idpro313.pro~ ~override~
   WRITE_ASCII 0x18 ~#tra_59~ #8
+
+/*
+luke
+**Earthquake**
+- Creatures with 10 or more Hit Dice should be immune to this spell (as per spell description)
+*/
+WITH_SCOPE BEGIN
+  COPY_EXISTING "idpro306.pro" "override"
+    WRITE_SHORT 0x200 (THIS BOR BIT15) // Single target flag
+    WRITE_LONG 0x240 (THIS BOR BIT10) // HD lookup flag
+    WRITE_SHORT 0x244 9 // Maximum level
+  BUT_ONLY_IF_IT_CHANGES
+END
 
 /////                                                  \\\\\
 ///// final batch of INCLUDEs and cross-patching       \\\\\
@@ -990,3 +1018,23 @@ END
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_functions.tpa~         // function for effect batches
 INCLUDE ~eefixpack/files/lib/cd_effect_batches_arrays_bg_bg2_iwd.tpa~ // array definitions for effect batches
 INCLUDE ~eefixpack/files/tph/tbd_vfx_removal_iwd.tph~                 // use effect batches to remove vfx from effects which have been removed
+
+/*
+luke
+**"7eyes.2da" vs. SPL/ITM files**
+- See "https://github.com/Gibberlings3/EE_Fixpack/pull/23" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\lib\gt_7eyes-o-matic.tph"
+  LAF "GT_7EYES-O-MATIC" END
+END
+
+/*
+luke
+**Opcode #39 overhaul**
+- See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for further details
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAF "OPCODE39_OVERHAUL" END
+END

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -138,6 +138,15 @@ WITH_SCOPE BEGIN
   LAUNCH_ACTION_FUNCTION "WING_BUFFET_VS_MR" END
 END
 
+/*
+luke
+**Op39 overhaul**
+*/
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack\files\tph\luke\op39_overhaul.tph"
+  LAUNCH_ACTION_FUNCTION "OPCODE39_OVERHAUL" END
+END
+
 /////                                                  \\\\\
 ///// dialogue fixes                                   \\\\\
 /////                                                  \\\\\

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -472,7 +472,7 @@ BEGIN
 					7 8 9 41 50 51 52 61 141 215 BEGIN // Visual effects (since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
 											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
@@ -488,7 +488,7 @@ BEGIN
 					139 BEGIN // Display string
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
@@ -521,7 +521,7 @@ BEGIN
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
 								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
@@ -561,7 +561,7 @@ BEGIN
 					174 WHEN ("%ITMSPL_effect_timing%" == 1) BEGIN // Play sound (initial sound - since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
 											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
@@ -577,7 +577,7 @@ BEGIN
 					174 WHEN ("%ITMSPL_effect_timing%" == 4) BEGIN // Play sound (expiry sound)
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 									PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
 										PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
@@ -639,7 +639,7 @@ BEGIN
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
 								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
@@ -660,7 +660,7 @@ BEGIN
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
 								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
@@ -689,7 +689,7 @@ BEGIN
 						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
 							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
 								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
 										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
 											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
 												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -1,0 +1,1122 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+
+See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for further details
+
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_ACTION_FUNCTION "OPCODE39_OVERHAUL"
+BEGIN
+	// Initialize
+	CLEAR_ARRAYS
+	ACTION_DEFINE_ARRAY "digit" BEGIN "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" END
+	ACTION_DEFINE_ARRAY "letter" BEGIN "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" END
+	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "SLEEP_IMMUNITY" END
+	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "NAUSEA_IMMUNITY" END
+	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "KNOCKBACK_IMMUNITY" END
+	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "HOPELESSNESS_IMMUNITY" END // same as SLEEP_IMMUNITY ...?
+	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "UNCONSCIOUSNESS_IMMUNITY" END // same as SLEEP_IMMUNITY ...?
+	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "KNOCKDOWN_GROUND-BASED_IMMUNITY" END // This is probably best done via other checks (f.i. RACE=WYVERN)
+
+	/*
+	==========================================================================================
+	**Opcode #39**
+	- Overall revision
+	==========================================================================================
+	*/
+
+	LAF "OPCODE39_OVERHAUL#DETERMINE_SLEEP_TYPE" RET_ARRAY "sleep_resref" "earthquake_resref" END
+
+	/*
+	========================================================================================
+	**Opcode #101 (p2==39)**
+	- The following code deals with creatures natural immunity to op39
+	========================================================================================
+	*/
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING_REGEXP "^.+\.cre$" "override"
+			PATCH_MATCH LONG_AT 0x28 WITH
+				// The following animations are hardcoded to be immune to op235. As a result, flag them as appropriate
+				IDS_OF_SYMBOL ("ANIMATE" "TANARRI")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_RED")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLACK")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_SILVER")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_GREEN")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_AQUA")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLUE")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BROWN")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_MULTICOLOR")
+				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_PURPLE")
+				IDS_OF_SYMBOL ("ANIMATE" "DEMOGORGON")
+				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_EARTH")
+				IDS_OF_SYMBOL ("ANIMATE" "SHAMBLING_MOUND")
+				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE")
+				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE_PURPLE")
+				IDS_OF_SYMBOL ("ANIMATE" "BURNING_MAN")
+				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_AIR")
+				IDS_OF_SYMBOL ("ANIMATE" "RAVER")
+				IDS_OF_SYMBOL ("ANIMATE" "SLAYER")
+				IDS_OF_SYMBOL ("ANIMATE" "SOLAR")
+				IDS_OF_SYMBOL ("ANIMATE" "DEVA_MONADIC")
+				IDS_OF_SYMBOL ("ANIMATE" "MELISSAN")
+				IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
+				IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
+				IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE") BEGIN
+					LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "opcode" = 328 "target" = 1 "timing" = 1 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "special" = 1 END
+				END
+				DEFAULT
+			END
+			// Check CRE effects
+			PATCH_WITH_SCOPE BEGIN
+				SET "found" = 0
+				PATCH_MATCH BYTE_AT 0x33 WITH
+					0 BEGIN
+						GET_OFFSET_ARRAY "fx_array" 0x2C4 4 0x2C8 4 0 0 0x30
+					END
+					1 BEGIN
+						GET_OFFSET_ARRAY "fx_array" CRE_V10_EFFECTS
+					END
+					DEFAULT
+						PATCH_FAIL "%DEST_FILE%: unknown effect version"
+				END
+				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+					PATCH_MATCH BYTE_AT 0x33 WITH
+						0 BEGIN
+							SET "fx_opcode" = SHORT_AT "%fx_off%"
+							SET "fx_parameter2" = SLONG_AT ("%fx_off%" + 0x8)
+						END
+						1 BEGIN
+							// Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header
+							SET "fx_opcode" = LONG_AT ("%fx_off%" + 0x10 - 0x8)
+							SET "fx_parameter2" = SLONG_AT ("%fx_off%" + 0x20 - 0x8)
+						END
+						DEFAULT
+					END
+					PATCH_MATCH "%fx_opcode%" WITH
+						101 WHEN ("%fx_parameter2%" == 39) BEGIN
+							// Immunity to effect => Effect: Sleep
+							SET "found" = 1
+						END
+						DEFAULT
+					END
+				END
+				PATCH_IF "%found%" BEGIN
+					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
+					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
+					LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
+				END
+			END
+			// Check CRE items
+			PATCH_WITH_SCOPE BEGIN
+				GET_OFFSET_ARRAY "itm_array" CRE_V10_ITEMS
+				PHP_EACH "itm_array" AS "itm_ind" => "itm_off" BEGIN
+					READ_ASCII ("%itm_off%" + 0x0) "itm_resref"
+					PATCH_MATCH "%itm_resref%" WITH
+						~bdbelhia~ ~demogorg~ ~behamu~ ~cibossb~ BEGIN END // Demogorgon, Belhifet, Luremaster (arbitrary boss immunities)
+						~bddraggh~ ~bdringgh~ ~sprngb02~ ~sprngb03~ ~sprngb04~ ~sprngs04~ ~sprngw01~ ~sprngs02~ "sprngw02" ~sprngw03~ ~sprngw04~ ~sprngz05~ BEGIN END // Exclusive to "Spirits/Ghosts" (Ghost Dragon, Shaman/Druid Spirits) (All Immunities - skip)
+						DEFAULT
+							INNER_ACTION BEGIN
+								COPY_EXISTING "%itm_resref%.itm" "override"
+									PATCH_IF ((BYTE_AT 0x18) BAND IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE")) BEGIN
+										// Skip droppable (player) items
+									END ELSE BEGIN
+										// Undroppable creature skin
+										SET "found_101#39" = 0
+										SET "revive_spl" = 0
+										GET_OFFSET_ARRAY "fx_array" ITM_V10_GEN_EFFECTS
+										PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+											PATCH_MATCH SHORT_AT "%fx_off%" WITH
+												101 WHEN (SLONG_AT ("%fx_off%" + 0x8) == 39) BEGIN
+													SET "found_101#39" = 1
+												END
+												98 BEGIN // Regeneration
+													SET "revive_spl" += 1
+												END
+												232 BEGIN // Cast spell on condition
+													PATCH_MATCH SLONG_AT ("%fx_off%" + 0x8) WITH
+														2 3 4 19 20 BEGIN // HP-related triggers
+															SET "revive_spl" += 1
+														END
+														DEFAULT
+													END
+												END
+												DEFAULT
+											END
+										END
+										PATCH_IF "%found_101#39%" BEGIN
+											PATCH_MATCH "%revive_spl%" WITH
+												2 BEGIN
+													PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+														PATCH_MATCH SHORT_AT "%fx_off%" WITH
+															267 BEGIN // Disable display string
+																LPF "GT_GET_STRING" INT_VAR "strref" = SLONG_AT ("%fx_off%" + 0x4) RET "string" END
+																PATCH_MATCH "%string%" WITH
+																	"Sleep" BEGIN
+																		WRITE_SHORT "%fx_off%" 998
+																	END
+																	DEFAULT
+																END
+															END
+															DEFAULT
+														END
+													END
+													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 998 END
+													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 END // Sleep
+													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 217 END // Power word, sleep
+												END
+												DEFAULT
+													LPF "CLONE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
+													LPF "CLONE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
+													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 END
+											END
+										END
+									END
+								BUT_ONLY IF_EXISTS
+							END
+					END
+				END
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	/*
+	====================================================================================================================================================================
+	**Opcode #101 (p2==39)**
+	- Polymorph-related ITMs
+	====================================================================================================================================================================
+	*/
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING_REGEXP "^.+\.itm$" "override"
+			SET "found_101#39" = 0
+			SET "found_135" = 0
+			GET_OFFSET_ARRAY "fx_array" ITM_V10_GEN_EFFECTS
+			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+				PATCH_MATCH SHORT_AT "%fx_off%" WITH
+					101 WHEN (SLONG_AT ("%fx_off%" + 0x8) == 39) BEGIN
+						SET "found_101#39" = 1
+					END
+					135 BEGIN
+						READ_ASCII ("%fx_off%" + 0x14) "cre_resref"
+						SET "found_135" = 1
+					END
+					DEFAULT
+				END
+			END
+			// 
+			PATCH_IF "%found_135%" BEGIN
+				SET "immunize_against_knockback" = 0
+				SET "immunize_against_earthquake" = 0
+				INNER_PATCH_FILE "%cre_resref%.cre" BEGIN
+					PATCH_MATCH LONG_AT 0x28 WITH
+						// The following animations are hardcoded to be immune to op235
+						IDS_OF_SYMBOL ("ANIMATE" "TANARRI")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_RED")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLACK")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_SILVER")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_GREEN")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_AQUA")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLUE")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BROWN")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_MULTICOLOR")
+						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_PURPLE")
+						IDS_OF_SYMBOL ("ANIMATE" "DEMOGORGON")
+						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_EARTH")
+						IDS_OF_SYMBOL ("ANIMATE" "SHAMBLING_MOUND")
+						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE")
+						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE_PURPLE")
+						IDS_OF_SYMBOL ("ANIMATE" "BURNING_MAN")
+						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_AIR")
+						IDS_OF_SYMBOL ("ANIMATE" "RAVER")
+						IDS_OF_SYMBOL ("ANIMATE" "SLAYER")
+						IDS_OF_SYMBOL ("ANIMATE" "SOLAR")
+						IDS_OF_SYMBOL ("ANIMATE" "DEVA_MONADIC")
+						IDS_OF_SYMBOL ("ANIMATE" "MELISSAN")
+						IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
+						IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
+						IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE") BEGIN
+							SET "immunize_against_knockback" = 1
+						END
+						DEFAULT
+					END
+					PATCH_MATCH BYTE_AT 0x271 WITH
+						IDS_OF_SYMBOL ("GENERAL" "UNDEAD") BEGIN
+							SET "immunize_against_earthquake" = 1
+						END
+						DEFAULT
+					END
+					PATCH_MATCH BYTE_AT 0x272 WITH
+						IDS_OF_SYMBOL ("RACE" "WYVERN")
+						IDS_OF_SYMBOL ("RACE" "BEHOLDER")
+						IDS_OF_SYMBOL ("RACE" "HARPY")
+						IDS_OF_SYMBOL ("RACE" "IMP")
+						IDS_OF_SYMBOL ("RACE" "MEPHIT")
+						IDS_OF_SYMBOL ("RACE" "DRAGON")
+						IDS_OF_SYMBOL ("RACE" "DEMILICH")
+						IDS_OF_SYMBOL ("RACE" "SHADOW")
+						IDS_OF_SYMBOL ("RACE" "SPECTRE")
+						IDS_OF_SYMBOL ("RACE" "WRAITH")
+						IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD")
+						IDS_OF_SYMBOL ("RACE" "WILL-O-WISP")
+						IDS_OF_SYMBOL ("RACE" "SLIME")
+						IDS_OF_SYMBOL ("RACE" "MIST") BEGIN
+							SET "immunize_against_earthquake" = 1
+						END
+						DEFAULT
+					END
+					PATCH_MATCH BYTE_AT 0x273 WITH
+						IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH")
+						IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") BEGIN
+							SET "immunize_against_earthquake" = 1
+						END
+						DEFAULT
+					END
+				END
+				// 
+				PATCH_IF "%immunize_against_knockback%" BEGIN
+					LPF "ADD_ITEM_EQEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 328 "target" = 1 "timing" = 2 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "special" = 1 END
+				END
+				PATCH_IF "%immunize_against_earthquake%" BEGIN
+					PHP_EACH "earthquake_resref" AS "resource" => "" BEGIN
+						LPF "ADD_ITEM_EQEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 318 "target" = 1 "timing" = 2 STR_VAR "resource" END
+					END
+				END
+				// 
+				PATCH_IF "%found_101#39%" BEGIN
+					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
+					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
+					LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
+				END
+			END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+
+	/*
+	====================================================================================================================================================================
+	**Opcode #101 (p2==39)**
+	- Everything below here is for Player SPLs/ITMs intended to block specific effects regardless of the recipient, each has to be manually specified (for best results)
+	====================================================================================================================================================================
+	*/
+
+	// IMM: Mind-affecting
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING
+			// SPL files
+			~%CLERIC_EXALTATION%.spl~ "override"
+			~%CLERIC_BLOOD_RAGE%.spl~ "override"
+			~%CLERIC_CHAOTIC_COMMANDS%.spl~ "override"
+			~%CLERIC_IMPERVIOUS_SANCTITY_OF_MIND%.spl~ "override"
+			~%WIZARD_MIND_BLANK%.spl~ "override"
+			~%MINSC_BERSERK%.spl~ "override"
+			~%SLAYER_ENEMY%.spl~ "override"
+			~%SLAYER_CHANGE_TWO%.spl~ "override"
+			~%SLAYER_CHANGE%.spl~ "override"
+			~%THREE_ROUND_ENCHANTMENT_IMMUNITY%.spl~ "override"
+			~%FIVE_ROUND_ENCHANTMENT_IMMUNITY%.spl~ "override"
+			~%BARBARIAN_RAGE%.spl~ "override"
+			~%BERSERKER_RAGE%.spl~ "override"
+			~ohrrage.spl~ "override" // Animal Rage
+			~ohtyr1.spl~ "override" // Exaltation
+			// ITM files
+			~gvalor1.itm~ "override" // Gauntlets of Valor
+			~amul17.itm~ "override" // Greenstone Amulet
+			~chalcy3.itm~ "override" // Greenstone Amulet
+			~helmdef.itm~ "override" // Helm of the Trusted Defender (IWD:EE)
+				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
+				LPF	"DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
+		BUT_ONLY IF_EXISTS
+	END
+
+	// IMM: Mind-affecting, Nausea
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING
+			// SPL files
+			~ohbbanno.spl~ "override" // Iron Golem Transformation
+			// ITM files
+				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
+				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
+				LPF	"DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
+		BUT_ONLY IF_EXISTS
+	END
+
+	/*
+	==============================================================================================================================================================
+	**Opcode #2 (Cure Sleep)**
+	- Everything below here is for SPLs/ITMs intended to remove specific effects regardless of the recipient, each has to be manually specified (for best results)
+	==============================================================================================================================================================
+	*/
+
+	WITH_SCOPE BEGIN
+		COPY_EXISTING "#cureslp.spl" "override"
+			PHP_EACH "sleep_resref" AS "resource" => "" BEGIN
+				LPF	"CLONE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 2 "opcode" = 321 "parameter1" = 0 "parameter2" = 2 "special" = 0 STR_VAR "resource" END
+			END
+			LPF	"DELETE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 2 END
+		BUT_ONLY_IF_IT_CHANGES
+	END
+END
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/*
+
+Helper functions
+
+*/
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_ACTION_FUNCTION "OPCODE39_OVERHAUL#DETERMINE_SLEEP_TYPE"
+RET_ARRAY
+	"sleep_resref"
+	"earthquake_resref"
+BEGIN
+	COPY_EXISTING_REGEXP "^.+\.\(itm\|spl\)$" "override"
+		PATCH_MATCH "%DEST_EXT%" WITH
+			"ITM" BEGIN
+				GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
+			END
+			"SPL" BEGIN
+				GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
+			END
+			DEFAULT
+				PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+		END
+		PATCH_CLEAR_ARRAY "fx_match"
+		TEXT_SPRINT "file_ext" "%DEST_EXT%" // keep a copy of original "%DEST_EXT%"
+		TEXT_SPRINT "file_res" "%DEST_RES%" // keep a copy of original "%DEST_RES%"
+		// Make sure troll / wolf revive spl files target '1|Self'
+		PATCH_MATCH "%file_res%" WITH
+			"bdwolfd1" "bdtroll1" BEGIN // wolf / troll revive spl files
+				LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "target" = 1 END
+			END
+			DEFAULT
+		END
+		// Record all op39 effects
+		PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+				// Take note of current effect's attributes
+				READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
+				READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
+				READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
+				READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
+				READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
+				READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
+				READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
+				READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
+				READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
+				READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
+				READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
+				READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
+				READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
+				READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
+				READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
+				READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
+				// Skip Self-targeted effects (that is to say, skip the various troll revive SPL files, WIZARD_GREATE_SHOUT, etc...)
+				PATCH_IF ("%ITMSPL_effect_opcode%" == 39) AND ("%ITMSPL_effect_target%" != 1) BEGIN
+					PATCH_MATCH "%ITMSPL_effect_timing%" WITH
+						1 2 5 6 7 8 9 BEGIN END // Ignore permanent and invalid timing modes
+						DEFAULT
+							DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
+								"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "%ab_ind%" , "%fx_ind%" => ""
+							END
+							WRITE_SHORT "%fx_off%" 999 // mark it for later detection
+					END
+				END
+			END
+		END
+		// 
+		SET "is_op39_on_all_abilities" = 0
+		PHP_EACH "fx_match" AS "fx_match_attribute" => "" BEGIN
+			PATCH_IF ("%fx_match_attribute_16%" == (SHORT_AT 0x68) - 1) BEGIN // Ability count starts from 0 (that is to say, the 1st Ability is Ability #0)
+				SET "is_op39_on_all_abilities" = 1
+			END
+		END
+		// For each op39 found, get its ancillary effects (if any)
+		PHP_EACH "fx_match" AS "fx_match_attribute" => "" BEGIN
+			// Initialize
+			SET "non-cosmetic_effects" = 0 // Suppose there are no non-cosmetic effects
+			SET "racial_sleep_immunity" = 0
+			TEXT_SPRINT "sleep_type" "Unconsciousness"
+			SET "ab_off" = ("%file_ext%" STR_EQ "ITM") ? LONG_AT 0x64 + ("%fx_match_attribute_16%" * 0x38) : LONG_AT 0x64 + ("%fx_match_attribute_16%" * 0x28)
+			SET "ab_ind" = "%fx_match_attribute_16%"
+			PATCH_CLEAR_ARRAY "fx_ancillary"
+			// Main
+			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+				// Take note of current effect's attributes
+				READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
+				READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
+				READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
+				READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
+				READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
+				READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
+				READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
+				READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
+				READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
+				READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
+				READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
+				READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
+				READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
+				READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
+				READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
+				READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
+				// 
+				PATCH_MATCH "%ITMSPL_effect_opcode%" WITH
+					999 BEGIN
+						PATCH_MATCH "%ITMSPL_effect_special%" WITH
+							126 BEGIN
+								TEXT_SPRINT "sleep_type" "Nausea"
+							END
+							DEFAULT
+						END
+						/*PATCH_IF ("%ITMSPL_effect_duration%" < 6) BEGIN
+							TEXT_SPRINT "sleep_type" "Knockback"
+						END*/
+					END
+					39 WHEN ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") AND ("%ITMSPL_effect_parameter1%" == "%fx_match_attribute_3%") AND ("%ITMSPL_effect_parameter2%" == "%fx_match_attribute_4%") BEGIN END // skip subspell in case of multiple op39 effects of the same type
+					7 8 9 41 50 51 52 61 141 215 BEGIN // Visual effects (since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+												"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+											END
+											WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+										END
+									END
+								END
+							END
+						END
+					END
+					139 BEGIN // Display string
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+															// WeiDU's GET_STRREF is language-dependant, so we need to fetch the corresponding string from the english version of "dialog.tlk"
+															LPF "GT_GET_STRING" INT_VAR "strref" = "%ITMSPL_effect_parameter1%" RET "string" END
+															PATCH_MATCH "%string%" WITH
+																"Sleep" "Unconscious" "Too high level for Color Spray" BEGIN
+																	DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																		"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																	END
+																	WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																END
+																DEFAULT
+																	SET "non-cosmetic_effects" = 1
+															END
+														END
+													END
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					142 BEGIN // Display portrait icon
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																	PATCH_MATCH "%ITMSPL_effect_parameter2%" WITH
+																		14 44 130 BEGIN // Sleep Hopelessness Unconscious
+																			DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																				"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																			END
+																			WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																		END
+																		126 BEGIN // Nauseated
+																			DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																				"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																			END
+																			WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																			TEXT_SPRINT "sleep_type" "Nausea"
+																		END
+																		DEFAULT
+																			SET "non-cosmetic_effects" = 1
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					174 WHEN ("%ITMSPL_effect_timing%" == 1) BEGIN // Play sound (initial sound - since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+												"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+											END
+											WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+										END
+									END
+								END
+							END
+						END
+					END
+					174 WHEN ("%ITMSPL_effect_timing%" == 4) BEGIN // Play sound (expiry sound)
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																END
+																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																WRITE_LONG ("%fx_off%" + 0x2C) 998 // mark it for later detection
+															END
+														END
+													END
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					321 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN // Remove effects by resource
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+												DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+													"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+												END
+												WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					318 324 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_MATCH "%ITMSPL_effect_parameter2%" WITH
+								15 19 BEGIN // RACE=ELF RACE=HALF_ELF
+									SET "racial_sleep_immunity" += 1
+									PATCH_IF ("racial_sleep_immunity" == 2) BEGIN
+										TEXT_SPRINT "sleep_type" "Sleep"
+									END
+								END
+								47 55 BEGIN // RACE=GOLEM|GENERAL=UNDEAD|RACE=MYCONID GENERAL=UNDEAD|RACE=GOLEM
+									TEXT_SPRINT "sleep_type" "Nausea"
+								END
+								DEFAULT
+							END
+						END
+					END
+					235 BEGIN // Wing buffet - ignore savingthrow and savebonus, match duration or less (see f.i. Dragon Wing Buffet "SPIN695.SPL")
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+													DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+													END
+													WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+													TEXT_SPRINT "sleep_type" "Knockback"
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					177 BEGIN // Use EFF file (see "https://github.com/Gibberlings3/EE_Fixpack/pull/37" for further details)
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+													INNER_PATCH_FILE "%ITMSPL_effect_resource%.eff" BEGIN
+														PATCH_MATCH LONG_AT 0x10 WITH
+															235 BEGIN // Wing buffet
+																TEXT_SPRINT "sleep_type" "Knockback"
+																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																END
+																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+															END
+															DEFAULT
+																SET "non-cosmetic_effects" = 1
+														END
+													END
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					328 BEGIN // Set splstate
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
+								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
+									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") BEGIN
+										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
+											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
+												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
+													PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
+														PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
+															PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
+																PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
+																	PATCH_IF ("%ITMSPL_effect_special%" == 1) AND ("%ITMSPL_effect_parameter2%" == 0) BEGIN
+																		DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
+																			"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
+																		END
+																		WRITE_SHORT "%fx_off%" 998 // mark it for later detection
+																		TEXT_SPRINT "sleep_type" "Hopelessness"
+																	END ELSE BEGIN
+																		SET "non-cosmetic_effects" = 1
+																	END
+																END
+															END
+														END
+													END
+												END
+											END
+										END
+									END
+								END
+							END
+						END
+					END
+					269 BEGIN // Shake screen (effect is usually self-targeted, so no need to match fields)
+						TEXT_SPRINT "sleep_type" "Knockdown_ground-based"
+					END
+					206 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN END
+					DEFAULT
+						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
+							SET "non-cosmetic_effects" = 1
+							//PATCH_PRINT "non-cosmetic_effects => %ITMSPL_effect_opcode%, resource => %ITMSPL_effect_resource%"
+						END
+				END
+			END
+			// Special cases
+			PATCH_MATCH "%file_res%" WITH
+				"sper12" BEGIN // Ixil's Spike +6 (Hit target is pinned for 3 rounds ...)
+					TEXT_SPRINT "sleep_type" "Knockdown_ground-based" // treat it as a sui generis earthquake
+				END
+				DEFAULT
+			END
+			// If there are non-cosmetic effects, patch accordingly
+			PATCH_IF ("%non-cosmetic_effects%") OR !("%is_op39_on_all_abilities%") BEGIN
+				//PATCH_PRINT "%file_res%.%file_ext% needs subspell ..."
+				PATCH_IF ("%non-cosmetic_effects%") BEGIN
+					PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+						//PATCH_PRINT "Restoring ancillary effect #%fx_ancillary_attribute_0% ..."
+						PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+							7 8 9 41 50 51 52 61 141 174 215 321 BEGIN // if there are non-cosmetic effects, then keep the cosmetic ones (plus op321) on the parent file ...
+								LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "silent" = 1 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 "opcode" = "%fx_ancillary_attribute_0%" END
+							END
+							DEFAULT
+								// op139, op142, ...
+								LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 END
+						END
+					END
+				END ELSE BEGIN
+					LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END
+				END
+				// Generate a filename for the child "*.spl" file
+				LPF "OPCODE39_OVERHAUL#GET_UNIQUE_FILE_NAME" RET "filename" END
+				// Keep track of some parent file data
+				PATCH_MATCH "%file_ext%" WITH
+					"SPL" BEGIN
+						SET "parent_spell_type" = SHORT_AT 0x1C
+						SET "parent_primary_type" = BYTE_AT 0x25
+						SET "parent_secondary_type" = BYTE_AT 0x27
+						READ_ASCII 0x3A "parent_icon_c"
+						READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
+						SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
+					END
+					"ITM" BEGIN
+						SET "parent_spell_type" = 4 // Innate
+						READ_ASCII 0x3A "parent_icon_c"
+						READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
+						SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
+						SET "parent_primary_type" = BYTE_AT ("%ab_off%" + 0x17)
+						SET "parent_secondary_type" = BYTE_AT ("%ab_off%" + 0x19)
+					END
+					DEFAULT
+				END
+				// Get current projectile type (so as to properly set the 'power' attribute)
+				LPF "OPCODE39_OVERHAUL#GET_PROJECTILE_TYPE" RET "projectile_type" END
+				// Create subspell
+				INNER_ACTION BEGIN
+					WITH_SCOPE BEGIN
+						CREATE "SPL" "%filename%"
+						COPY_EXISTING "%filename%.spl" "override"
+							/* Header */
+							WRITE_LONG NAME1 "-1"
+							WRITE_LONG NAME2 "-1"
+							WRITE_SHORT 0x1C "%parent_spell_type%"
+							WRITE_BYTE 0x25 "%parent_primary_type%"
+							WRITE_BYTE 0x27 "%parent_secondary_type%"
+							WRITE_LONG 0x34 1 // Spell level
+							WRITE_ASCII 0x3A "%parent_icon_c%"
+							WRITE_LONG UNIDENTIFIED_DESC "-1"
+							WRITE_LONG DESC "-1"
+							WRITE_LONG 0x64 0x72 // Extended Header offset
+							WRITE_SHORT 0x68 1 // Extended Header count
+							WRITE_LONG 0x6A 0x9A // Feature Block Table offset
+							INSERT_BYTES 0x72 0x28
+							/* Extended Header */
+							WRITE_BYTE 0x72 1 // Ability type
+							WRITE_SHORT 0x74 4 // Ability location: F13 (Special Ability)
+							WRITE_ASCII 0x76 ~%parent_icon_b%~ // Ability icon
+							WRITE_BYTE 0x7E "%parent_ability_target%" // Ability target
+							WRITE_SHORT 0x80 0x7FFF // Ability range
+							WRITE_SHORT 0x82 1 // Minimum level
+							WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
+						BUT_ONLY
+					END
+				END
+				// 
+				LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "header" = "%ab_ind%" "multi_match" = 1 "match_opcode" = 999 "opcode" = 146 "parameter1" = 0 "parameter2" = 1 "timing" = 1 "duration" = 0 "special" = 0 STR_VAR "resource" = "%filename%" END
+				INNER_ACTION BEGIN
+					COPY_EXISTING "%filename%.spl" "override"
+						/* Feature blocks */
+						PATCH_MATCH "%sleep_type%" WITH
+							"Sleep" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
+							END
+							"Unconsciousness" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
+							END
+							"Nausea" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+							END
+							"Hopelessness" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
+							END
+							"Knockback" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+							END
+							"Knockdown_ground-based" BEGIN
+								TEXT_SPRINT $"earthquake_resref"("%DEST_RES%") ""
+								//LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								PATCH_IF !("%game_is_iwdee%") BEGIN
+									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
+							END
+							DEFAULT
+						END
+						// 
+						LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_match_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+							PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+								7 8 9 41 50 51 52 61 141 215 WHEN ("%non-cosmetic_effects%") BEGIN END
+								174 WHEN !(("%non-cosmetic_effects%") AND ("%fx_ancillary_attribute_5%" == 4)) BEGIN END // skip non-expiry sound effects
+								DEFAULT
+									PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
+										321 BEGIN
+											LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%DEST_RES%" END
+										END
+										DEFAULT
+											LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+									END
+							END
+						END
+					BUT_ONLY_IF_IT_CHANGES
+				END
+			END ELSE BEGIN
+				// Just reorder effect stack
+				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 999 "multi_match" = 1 END // main effect
+				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END // ancillary effects
+				// 
+				PATCH_MATCH "%file_ext%" WITH
+					"SPL" BEGIN
+						SET "opcode" = (SLONG_AT NAME1 > 0 ? 324 : 318)
+					END
+					"ITM" BEGIN
+						SET "opcode" = ((LONG_AT 0x18 BAND (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE"))) == (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE")) ? 324 : 318)
+					END
+					DEFAULT
+				END
+				PATCH_MATCH "%sleep_type%" WITH
+					"Sleep" BEGIN
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
+					END
+					"Unconsciousness" BEGIN
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
+					END
+					"Nausea" BEGIN
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+					END
+					"Hopelessness" BEGIN
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
+					END
+					"Knockback" BEGIN
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+					END
+					"Knockdown_ground-based" BEGIN
+						TEXT_SPRINT $"earthquake_resref"("%file_res%") ""
+						PATCH_MATCH "%file_ext%" WITH
+							"SPL" BEGIN
+								//LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								PATCH_IF !("%game_is_iwdee%") BEGIN
+									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							"ITM" BEGIN
+								//LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								PATCH_IF !("%game_is_iwdee%") BEGIN
+									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
+							END
+							DEFAULT
+						END
+					END
+					DEFAULT
+				END
+				PATCH_MATCH "%file_ext%" WITH
+					"SPL" BEGIN
+						LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = "%fx_match_attribute_6%" "duration" = "%fx_match_attribute_7%" "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+							LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "header" = ("%ab_ind%" + 1) "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = "%fx_ancillary_attribute_2%" "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = "%fx_ancillary_attribute_6%" "duration" = "%fx_ancillary_attribute_7%" "probability1" = "%fx_ancillary_attribute_8%" "probability2" = "%fx_ancillary_attribute_9%" "dicenumber" = "%fx_ancillary_attribute_11%" "dicesize" = "%fx_ancillary_attribute_12%" "savingthrow" = "%fx_ancillary_attribute_13%" "savebonus" = "%fx_ancillary_attribute_14%" "special" = "%fx_ancillary_attribute_15%" STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+						END
+					END
+					"ITM" BEGIN
+						LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = "%fx_match_attribute_6%" "duration" = "%fx_match_attribute_7%" "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
+						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
+							LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "header" = ("%ab_ind%" + 1) "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = "%fx_ancillary_attribute_2%" "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = "%fx_ancillary_attribute_6%" "duration" = "%fx_ancillary_attribute_7%" "probability1" = "%fx_ancillary_attribute_8%" "probability2" = "%fx_ancillary_attribute_9%" "dicenumber" = "%fx_ancillary_attribute_11%" "dicesize" = "%fx_ancillary_attribute_12%" "savingthrow" = "%fx_ancillary_attribute_13%" "savebonus" = "%fx_ancillary_attribute_14%" "special" = "%fx_ancillary_attribute_15%" STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
+						END
+					END
+					DEFAULT
+				END
+			END
+		END
+		// Clean up
+		PATCH_WITH_SCOPE BEGIN
+			PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+				GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
+				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+					PATCH_MATCH SHORT_AT "%fx_off%" WITH
+						174 WHEN SLONG_AT ("%fx_off%" + 0x2C) == 998 BEGIN
+							WRITE_SHORT "%fx_off%" 998
+						END
+						DEFAULT
+					END
+				END
+				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "match_special" = 998 END
+			END
+		END
+	BUT_ONLY_IF_IT_CHANGES
+END
+
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Determine the projectile type (Single or AoE) of the current SPL/ITM ability
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_PATCH_FUNCTION "OPCODE39_OVERHAUL#GET_PROJECTILE_TYPE"
+RET
+	"projectile_type"
+BEGIN
+	SET "projectile_type" = 2 // Single target
+	PATCH_MATCH "%file_ext%" WITH
+		"SPL" BEGIN
+			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x26) - 1)
+		END
+		"ITM" BEGIN
+			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x2A) - 1)
+		END
+		DEFAULT
+	END
+	INNER_PATCH_FILE "%projectile_res%.pro" BEGIN
+		READ_SHORT 0x8 "projectile_type"
+	END
+END
+
+DEFINE_PATCH_FUNCTION "OPCODE39_OVERHAUL#GET_UNIQUE_FILE_NAME"
+RET
+	"filename"
+BEGIN
+	PATCH_IF (STRING_LENGTH "%file_res%" <= 7) BEGIN
+		SNPRINT "-1" "last_character" "%file_res%"
+		PATCH_MATCH "%last_character%" WITH
+			"[a-z]" BEGIN
+				SET "count" = 0
+				TEXT_SPRINT "suffix" $"digit"("%count%") // "0"
+				TEXT_SPRINT "filename" "%file_res%%suffix%"
+				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
+					SET "count" += 1
+					TEXT_SPRINT "suffix" $"digit"("%count%")
+					TEXT_SPRINT "filename" "%file_res%%suffix%"
+				END
+				PATCH_IF ("%count%" == 10) BEGIN
+					TO_UPPER "file_res"
+					TO_UPPER "file_ext"
+					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
+				END
+			END
+			"[0-9]" BEGIN
+				SET "count" = 0
+				TEXT_SPRINT "suffix" $"letter"("%count%") // "a"
+				TEXT_SPRINT "filename" "%file_res%%suffix%"
+				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
+					SET "count" += 1
+					TEXT_SPRINT "suffix" $"letter"("%count%")
+					TEXT_SPRINT "filename" "%file_res%%suffix%"
+				END
+				PATCH_IF ("%count%" == 26) BEGIN
+					TO_UPPER "file_res"
+					TO_UPPER "file_ext"
+					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
+				END
+			END
+			DEFAULT
+				TO_UPPER "file_res"
+				TO_UPPER "file_ext"
+				LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
+		END
+	END ELSE BEGIN
+		TO_UPPER "file_res"
+		TO_UPPER "file_ext"
+		LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
+	END
+	//
+	INNER_PATCH_SAVE "filename" "%filename%" BEGIN
+		REPLACE_TEXTUALLY EVALUATE_REGEXP "^__" "cd"
+	END
+	TO_LOWER "filename"
+END

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -82,18 +82,9 @@ BEGIN
 						PATCH_FAIL "%DEST_FILE%: unknown effect version"
 				END
 				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-					PATCH_MATCH BYTE_AT 0x33 WITH
-						0 BEGIN
-							SET "fx_opcode" = SHORT_AT "%fx_off%"
-							SET "fx_parameter2" = SLONG_AT ("%fx_off%" + 0x8)
-						END
-						1 BEGIN
-							// Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header
-							SET "fx_opcode" = LONG_AT ("%fx_off%" + 0x10 - 0x8)
-							SET "fx_parameter2" = SLONG_AT ("%fx_off%" + 0x20 - 0x8)
-						END
-						DEFAULT
-					END
+					// Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header
+					SET "fx_opcode" = BYTE_AT 0x33 ? LONG_AT ("%fx_off%" + 0x10 - 0x8) : SHORT_AT "%fx_off%"
+					SET "fx_parameter2" = BYTE_AT 0x33 ? SLONG_AT ("%fx_off%" + 0x20 - 0x8) SLONG_AT ("%fx_off%" + 0x8)
 					PATCH_MATCH "%fx_opcode%" WITH
 						101 WHEN ("%fx_parameter2%" == 39) BEGIN
 							// Immunity to effect => Effect: Sleep

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -8,434 +8,481 @@ See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for furt
 
 DEFINE_ACTION_FUNCTION "OPCODE39_OVERHAUL"
 BEGIN
-	ACTION_IF (MOD_IS_INSTALLED "EEex.tp2" 0) BEGIN
-		LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "SLEEP_IMMUNITY" END
-		LAF "GET_BULKY_CREATURES" RET_ARRAY "bulky_creature_list" END // get all creatures whose animation is hardcoded to be immune to op235 (Wing Buffet)
+	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "SLEEP_IMMUNITY" END
+	LAF "GET_BULKY_CREATURES" RET_ARRAY "bulky_creature_list" END // get all creatures whose animation is hardcoded to be immune to op235 (Wing Buffet)
 
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-		/*
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
 
-		Sleep / Unconscious
+	Sleep / Unconscious
 
-		*/
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	*/
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-		WITH_SCOPE BEGIN
-			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
-				"SPLSTATE" , "SLEEP_IMMUNITY" => 110
+	WITH_SCOPE BEGIN
+		ACTION_DEFINE_ASSOCIATIVE_ARRAY "op39_overhaul_reserved_hash" BEGIN
+			"SPLSTATE" , "SLEEP_IMMUNITY" => 110
+		END
+		ACTION_MATCH 1 WITH
+			GAME_IS "bgee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+					"bdblun07.spl" => "" // Backwhacker +2
+					"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+					"bdxbow01.spl" => "" // Astral Crossbow +2
+					"spcl751a.spl" => "spcl751c" // Jester's Song
+					"%PSIONIC_MIND_BLAST%.spl" => ""
+					"%MIND_CRIPPLE%.spl" => ""
+					"%MEPHIT_COLOR_SPRAY%.spl" => ""
+					"%CLERIC_COMMAND%.spl" => ""
+					"%CLERIC_GREATER_COMMAND%.spl" => ""
+					"%WIZARD_COLOR_SPRAY%.spl" => ""
+					"%WIZARD_SLEEP%.spl" => ""
+					"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
+					"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+					//
+					"bdgibbbr.itm" => "bdgibbbr" // used by "bdgibbbr.cre" (Brood Gibberling)
+					"bdspidga.itm" => "bdspdga0" // used by "bdspidga.cre" (Gargantuan Spider)
+					"bdwyrmli.itm" => "bdwyrmli" // used by "bdwyrmli.cre" (Blind Albino Wyrmling)
+					"cdfampsd.itm" => ""
+					"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep +1
+					"dwdart01.itm" => "dwdart01" // Drow Dart of Sleep +1
+					"psdclaw.itm" => ""
+					"wand08.itm" => "wand08" // Wand of Sleep
+				END
 			END
-			ACTION_MATCH 1 WITH
-				GAME_IS "bgee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
-						"bdblun07.spl" => "" // Backwhacker +2
-						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
-						"bdxbow01.spl" => "" // Astral Crossbow +2
-						"spcl751a.spl" => "spcl751c" // Jester's Song
-						"%PSIONIC_MIND_BLAST%.spl" => ""
-						"%MIND_CRIPPLE%.spl" => ""
-						"%MEPHIT_COLOR_SPRAY%.spl" => ""
-						"%CLERIC_COMMAND%.spl" => ""
-						"%CLERIC_GREATER_COMMAND%.spl" => ""
-						"%WIZARD_COLOR_SPRAY%.spl" => ""
-						"%WIZARD_SLEEP%.spl" => ""
-						"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
-						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
-						//
-						"bdgibbbr.itm" => "bdgibbbr" // used by "bdgibbbr.cre" (Brood Gibberling)
-						"bdspidga.itm" => "bdspidga" // used by "bdspidga.cre" (Gargantuan Spider)
-						"bdwyrmli.itm" => "bdwyrmli" // used by "bdwyrmli.cre" (Blind Albino Wyrmling)
-						"cdfampsd.itm" => ""
-						"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep +1
-						"dwdart01.itm" => "dwdart01" // Drow Dart of Sleep +1
-						"psdclaw.itm" => ""
-						"wand08.itm" => "wand08" // Wand of Sleep
-					END
+			GAME_IS "bg2ee eet" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+					"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+					"spcl751a.spl" => "spcl751c" // Jester's Song
+					"%PSIONIC_MIND_BLAST%.spl" => ""
+					"%MIND_CRIPPLE%.spl" => ""
+					"%MEPHIT_COLOR_SPRAY%.spl" => ""
+					"%CLERIC_COMMAND%.spl" => ""
+					"%CLERIC_GREATER_COMMAND%.spl" => ""
+					"%WIZARD_COLOR_SPRAY%.spl" => ""
+					"%WIZARD_SLEEP%.spl" => ""
+					"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
+					"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+					//
+					"cdfampsd.itm" => ""
+					"dagg13.itm" => "dagg13" // Pixie Prick +3
+					"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep
+					"ohbbrvgr.itm" => "ohbbrvgr" // used by "ohbbrvgr.cre" (The Ravager)
+					"psdclaw.itm" => ""
+					"staf15.itm" => "" // Staff of Air +2
+					"wand08.itm" => "wand08" // Wand of Sleep
 				END
-				GAME_IS "bg2ee eet" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
-						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
-						"spcl751a.spl" => "spcl751c" // Jester's Song
-						"%PSIONIC_MIND_BLAST%.spl" => ""
-						"%MIND_CRIPPLE%.spl" => ""
-						"%MEPHIT_COLOR_SPRAY%.spl" => ""
-						"%CLERIC_COMMAND%.spl" => ""
-						"%CLERIC_GREATER_COMMAND%.spl" => ""
-						"%WIZARD_COLOR_SPRAY%.spl" => ""
-						"%WIZARD_SLEEP%.spl" => ""
-						"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
-						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
-						//
-						"cdfampsd.itm" => ""
-						"dagg13.itm" => "dagg13" // Pixie Prick +3
-						"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep
-						"ohbbrvgr.itm" => "ohbbrvgr" // used by "ohbbrvgr.cre" (The Ravager)
-						"psdclaw.itm" => ""
-						"staf15.itm" => "" // Staff of Air +2
-						"wand08.itm" => "wand08" // Wand of Sleep
-					END
-				END
-				GAME_IS "iwdee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
-						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
-						"spcl751a.spl" => "spcl751c" // Jester's Song
-						"%INNATE_BEHOLDER_SLEEP%.spl" => ""
-						"%INNATE_JACKALWERE_GAZE_INTERNAL%.spl" => ""
-						"%MIND_CRIPPLE%.spl" => ""
-						"%CLERIC_COMMAND%.spl" => ""
-						"%CLERIC_SMASHING_WAVE%.spl" => ""
-						"%CLERIC_GREATER_COMMAND%.spl" => ""
-						"%TRAP_SLEEP%.spl" => "%TRAP_SLEEP%c"
-						"%WIZARD_COLOR_SPRAY%.spl" => ""
-						"%WIZARD_SLEEP%.spl" => ""
-						"%WIZARD_POWER_WORD_SLEEP%.spl" => ""
-						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
-						//
-						"cdfampsd.itm" => ""
-						"uhalb3b.itm" => "uhalb3b" // Darig's Rest +2
-						"wand08.itm" => "wand08" // Wand of Sleep
-					END
-				END
-				DEFAULT
-					FAIL "Game not supported"
 			END
-			ACTION_PHP_EACH "sleep_unconscious_list" AS "file" => "subspell" BEGIN
-				COPY_EXISTING "%file%" "override"
-					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
-						// Transfer effects onto a new SPL file (if needed)
-						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
-						//
-						INNER_ACTION BEGIN
+			GAME_IS "iwdee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+					"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+					"spcl751a.spl" => "spcl751c" // Jester's Song
+					"%INNATE_BEHOLDER_SLEEP%.spl" => ""
+					"%INNATE_JACKALWERE_GAZE_INTERNAL%.spl" => ""
+					"%MIND_CRIPPLE%.spl" => ""
+					"%CLERIC_COMMAND%.spl" => ""
+					"%CLERIC_SMASHING_WAVE%.spl" => ""
+					"%CLERIC_GREATER_COMMAND%.spl" => ""
+					"%TRAP_SLEEP%.spl" => "%TRAP_SLEEP%c"
+					"%WIZARD_COLOR_SPRAY%.spl" => ""
+					"%WIZARD_SLEEP%.spl" => ""
+					"%WIZARD_POWER_WORD_SLEEP%.spl" => ""
+					"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+					//
+					"cdfampsd.itm" => ""
+					"uhalb3b.itm" => "uhalb3b" // Darig's Rest +2
+					"wand08.itm" => "wand08" // Wand of Sleep
+				END
+			END
+			DEFAULT
+				FAIL "Game not supported"
+		END
+		ACTION_PHP_EACH "sleep_unconscious_list" AS "file" => "subspell" BEGIN
+			COPY_EXISTING "%file%" "override"
+				PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+					// Transfer effects onto a new SPL file (if needed)
+					LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell"
+						INT_VAR
+							"effectID" = 39
+						STR_VAR
+							"subspell_resref" = "%subspell%"
+							"splstate" = "SLEEP_IMMUNITY"
+							"string" = "Sleep, Unconscious"
+							"icon" = "14 44 130"
+					END
+				END ELSE BEGIN
+					LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" INT_VAR "effectID" = 39 END
+					LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+				END
+			BUT_ONLY IF_EXISTS
+		END
+	END
+
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
+
+	"Forced" Sleep (f.i. cutscenes, dialogs, troll/wolf-death mechanics, ...)
+
+	*/
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+	WITH_SCOPE BEGIN
+		ACTION_MATCH 1 WITH
+			GAME_IS "bgee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+					"bdgassa1.spl" => "" // used by "bd0103.bcs" , "bd0104.bcs" , "bddausto.bcs" , "bddausto.dlg" , "bdtiax.dlg"
+					"bdgassa3.spl" => "" // unused...?
+					"bdsleep.spl" => "" // used by "bd6100.bcs" , "bdcutslp.bcs"
+					"bdtroll1.spl" => ""
+					"bdulori.spl" => ""
+					"bdwolfd1.spl" => ""
+					"shoal1.spl" => "shoal1b" // Nereid's Kiss (used by "shoal.dlg")
+					"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // unused...?
+					"%SURE_SLEEP%.spl" => "" // used by "bpfinal.bcs" , "chasel3.bcs" , "drunk.dlg"
+					"%TROLL_SLEEP%.spl" => ""
+					"trollreg.spl" => ""
+					//
+					"bddagg06.itm" => "" // Dagger +2 (used by "bdfinal[1-2].cre", "bdfinal4.cre")
+					"bddagg07.itm" => "" // Throwing Dagger +1 (used by "bdfinal3.cre", "bdfinal5.cre")
+				END
+			END
+			GAME_IS "bg2ee eet" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+					"cdhgtrl.spl" => ""
+					"cdtorgal.spl" => ""
+					"cdtrlblz.spl" => ""
+					"ch3drain.spl" => "" // unused...?
+					"ch3flash.spl" => "" // unused...?
+					"ch3weak.spl" => "" // unused...?
+					"jwfall.spl" => "" // used by "itladr1[a-b].dlg" , "itladr2[a-b].dlg" , "itladr3[a-b].dlg"
+					"jwsleep.spl" => "" // used by "cut233g.bcs"
+					"ohddivrt.spl" => "" // used by "ohdddorl.bcs" , "ohddixth.bcs"
+					"%ABAZIGAL_SHOCKWAVE%.spl" => "%ABAZIGAL_SHOCKWAVE%b" // used by "abazdrag.bcs"
+					"%SAREVOK_SOULSTEAL%.spl" => "" // used by "cut206[a-b].bcs"
+					"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // used by "sarvie01.dlg" , "viekang.dlg"
+					"%SURE_SLEEP%.spl" => "" // used by "cut28a.bcs" , "cut49a.bcs" , "cut67a.bcs" , "drunk.dlg"
+					"%TROLL_SLEEP%.spl" => ""
+					"trollreg.spl" => ""
+				END
+			END
+			GAME_IS "iwdee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+					"#jedslp.spl" => "" // used by "doldjed.dlg"
+					"cdiwdtr1.spl" => ""
+					"cdiwdtr2.spl" => ""
+					"%INNATE_RETRIBUTION%.spl" => "" // used by "bcscut2a.bcs" , "bcscut2d.bcs"
+					"%INNATE_WEREWOLF_DEATH%.spl" => ""
+					"%INNATE_WYLFDENES_DEATH_ANIMATION%.spl" => ""
+					"%INNATE_DRAGON_DEATH_ANIMATION%.spl" => ""
+					"%INNATE_POLYMORPH_TO_DOG%.spl" => ""
+					"%WIZARD_GREAT_SHOUT%.spl" => ""
+				END
+			END
+			DEFAULT
+				FAIL "Game not supported"
+		END
+		ACTION_PHP_EACH "forced_sleep_list" AS "file" => "subspell" BEGIN
+			COPY_EXISTING "%file%" "override"
+				PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+					// Transfer effects onto a new SPL file (if needed)
+					LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell"
+						INT_VAR
+							"effectID" = 39
+						STR_VAR
+							"subspell_resref" = "%subspell%"
+							"string" = "Sleep, Unconscious"
+							"icon" = "14 44 126 130"
+					END
+					//
+					INNER_ACTION BEGIN
+						WITH_SCOPE BEGIN
 							COPY_EXISTING "%subspell%.spl" "override"
-								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+								LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END
 							BUT_ONLY
 						END
-					END ELSE BEGIN
-						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
-						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
 					END
-				BUT_ONLY IF_EXISTS
-			END
+				END ELSE BEGIN
+					LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" INT_VAR "effectID" = 39 END
+					LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END
+				END
+			BUT_ONLY IF_EXISTS
 		END
+	END
 
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-		/*
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
 
-		"Forced" Sleep (f.i. cutscenes, dialogs, troll/wolf-death mechanics, ...)
+	Physical knockdown (Earthquake)
 
-		*/
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	*/
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-		WITH_SCOPE BEGIN
-			ACTION_MATCH 1 WITH
-				GAME_IS "bgee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
-						"bdgassa1.spl" => "" // used by "bd0103.bcs" , "bd0104.bcs" , "bddausto.bcs" , "bddausto.dlg" , "bdtiax.dlg"
-						"bdgassa3.spl" => "" // unused...?
-						"bdsleep.spl" => "" // used by "bd6100.bcs" , "bdcutslp.bcs"
-						"bdtroll1.spl" => ""
-						"bdulori.spl" => ""
-						"bdwolfd1.spl" => ""
-						"shoal1.spl" => "shoal1b" // Nereid's Kiss (used by "shoal.dlg")
-						"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // unused...?
-						"%SURE_SLEEP%.spl" => "" // used by "bpfinal.bcs" , "chasel3.bcs" , "drunk.dlg"
-						"%TROLL_SLEEP%.spl" => ""
-						"trollreg.spl" => ""
-						//
-						"bddagg06.itm" => "" // Dagger +2 (used by "bdfinal[1-2].cre", "bdfinal4.cre")
-						"bddagg07.itm" => "" // Throwing Dagger +1 (used by "bdfinal3.cre", "bdfinal5.cre")
-					END
-				END
-				GAME_IS "bg2ee eet" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
-						"cdhgtrl.spl" => ""
-						"cdtorgal.spl" => ""
-						"cdtrlblz.spl" => ""
-						"ch3drain.spl" => "" // unused...?
-						"ch3flash.spl" => "" // unused...?
-						"ch3weak.spl" => "" // unused...?
-						"jwfall.spl" => "" // used by "itladr1[a-b].dlg" , "itladr2[a-b].dlg" , "itladr3[a-b].dlg"
-						"jwsleep.spl" => "" // used by "cut233g.bcs"
-						"ohddivrt.spl" => "" // used by "ohdddorl.bcs" , "ohddixth.bcs"
-						"%ABAZIGAL_SHOCKWAVE%.spl" => "%ABAZIGAL_SHOCKWAVE%b" // used by "abazdrag.bcs"
-						"%SAREVOK_SOULSTEAL%.spl" => "" // used by "cut206[a-b].bcs"
-						"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // used by "sarvie01.dlg" , "viekang.dlg"
-						"%SURE_SLEEP%.spl" => "" // used by "cut28a.bcs" , "cut49a.bcs" , "cut67a.bcs" , "drunk.dlg"
-						"%TROLL_SLEEP%.spl" => ""
-						"trollreg.spl" => ""
-					END
-				END
-				GAME_IS "iwdee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
-						"#jedslp.spl" => "" // used by "doldjed.dlg"
-						"cdiwdtr1.spl" => ""
-						"cdiwdtr2.spl" => ""
-						"%INNATE_RETRIBUTION%.spl" => "" // used by "bcscut2a.bcs" , "bcscut2d.bcs"
-						"%INNATE_WEREWOLF_DEATH%.spl" => ""
-						"%INNATE_WYLFDENES_DEATH_ANIMATION%.spl" => ""
-						"%INNATE_DRAGON_DEATH_ANIMATION%.spl" => ""
-						"%INNATE_POLYMORPH_TO_DOG%.spl" => ""
-						"%WIZARD_GREAT_SHOUT%.spl" => ""
-					END
-				END
-				DEFAULT
-					FAIL "Game not supported"
-			END
-			ACTION_PHP_EACH "forced_sleep_list" AS "file" => "subspell" BEGIN
-				COPY_EXISTING "%file%" "override"
-					LPF "EEex_bypass_op101" END
-					//
-					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
-						// Transfer effects onto a new SPL file (if needed)
-						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
-					END ELSE BEGIN
-						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
-					END
-				BUT_ONLY IF_EXISTS
-			END
+	WITH_SCOPE BEGIN
+		ACTION_DEFINE_ASSOCIATIVE_ARRAY "op39_overhaul_reserved_hash" BEGIN
+			"GENERAL" , "WEAPON" => 103 // reason: Mordenkainen's Sword (can levitate)
+			//
+			"RACE" , "DRAGON" => 104 // reason: can fly
+			"RACE" , "WYVERN" => 104 // reason: can fly
+			"RACE" , "DEMILICH" => 104 // reason: can levitate
+			"RACE" , "HARPY" => 104 // reason: can fly
+			"RACE" , "MEPHIT" => 104 // reason: can fly
+			"RACE" , "IMP" => 104 // reason: can fly
+			"RACE" , "SPECTRAL_UNDEAD" => 104 // reason: incorporeal creature
+			"RACE" , "SPECTRE" => 104 // reason: incorporeal creature
+			"RACE" , "WRAITH" => 104 // reason: incorporeal creature
+			"RACE" , "SHADOW" => 104 // reason: incorporeal creature
+			"RACE" , "SLIME" => 104 // reason: cannot fall to the ground
+			"RACE" , "BEHOLDER" => 104 // reason: can levitate
+			"RACE" , "FEYR" => 104 // reason: can levitate...?
+			"RACE" , "WILL-O-WISP" => 104 // reason: can levitate
+			//
+			"CLASS" , "ELEMENTAL_EARTH" => 105 // reason: should be immune to its own element
+			"CLASS" , "GENIE_DAO" => 105 // reason: should be immune to its own element
+			//
+			"PERSONAL_SPACE" , "" => 13 // PERSONALSPACE>3 (this is inherited from iwdee), reason: "large" creatures
 		END
-
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-		/*
-
-		Physical knockdown (Earthquake)
-
-		*/
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-		WITH_SCOPE BEGIN
-			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
-				"GENERAL" , "WEAPON" => 103
-				//
-				"RACE" , "DRAGON" => 104
-				"RACE" , "WYVERN" => 104
-				"RACE" , "DEMILICH" => 104
-				"RACE" , "HARPY" => 104
-				"RACE" , "MEPHIT" => 104
-				"RACE" , "IMP" => 104
-				"RACE" , "SPECTRAL_UNDEAD" => 104
-				"RACE" , "SPECTRE" => 104
-				"RACE" , "WRAITH" => 104
-				"RACE" , "SHADOW" => 104
-				"RACE" , "SLIME" => 104
-				"RACE" , "BEHOLDER" => 104
-				"RACE" , "FEYR" => 104
-				"RACE" , "WILL-O-WISP" => 104
-				//
-				"CLASS" , "ELEMENTAL_EARTH" => 105
-				//
-				"PERSONAL_SPACE" , "" => 13 // PERSONALSPACE>3 (this is inherited from iwdee)
+		ACTION_MATCH 1 WITH
+			GAME_IS "bgee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+					"bpgiaqke.spl" => ""
+					"spogre01.spl" => "spogre03" // Earthquake
+					"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
+				END
 			END
-			ACTION_MATCH 1 WITH
-				GAME_IS "bgee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
-						"bpgiaqke.spl" => ""
-						"spogre01.spl" => "spogre03" // Earthquake
-						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
-					END
-				END
-				GAME_IS "bg2ee eet" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
-						"jwsiege.spl" => "jwsiege2"
-						"ohbquake.spl" => "ohbquak2" // Earthquake
-						"spogre01.spl" => "spogre03" // Earthquake
-						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
-						//
-						"sper12.itm" => "sper12" // Ixil's Spike +6 (consider this as a special, edge-case earthquake)
-					END
-				END
-				GAME_IS "iwdee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
-						"spogre01.spl" => "spogre03"
-						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
-					END
-				END
-				DEFAULT
-					FAIL "Game not supported"
-			END
-			ACTION_PHP_EACH "earthquake_list" AS "file" => "subspell" BEGIN
-				COPY_EXISTING "%file%" "override"
-					LPF "EEex_bypass_op101" END
+			GAME_IS "bg2ee eet" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+					"jwsiege.spl" => "jwsiege2"
+					"ohbquake.spl" => "ohbquak2" // Earthquake
+					"spogre01.spl" => "spogre03" // Earthquake
+					"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
 					//
-					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
-						// Transfer effects onto a new SPL file (if needed)
-						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
-						//
-						INNER_ACTION BEGIN
+					"sper12.itm" => "sper12" // Ixil's Spike +6 (consider this as a special, edge-case earthquake)
+				END
+			END
+			GAME_IS "iwdee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+					"spogre01.spl" => "spogre03"
+					"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
+				END
+			END
+			DEFAULT
+				FAIL "Game not supported"
+		END
+		ACTION_PHP_EACH "earthquake_list" AS "file" => "subspell" BEGIN
+			COPY_EXISTING "%file%" "override"
+				PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+					// Transfer effects onto a new SPL file (if needed)
+					LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell"
+						INT_VAR
+							"effectID" = 39
+						STR_VAR
+							"subspell_resref" = "%subspell%"
+							"string" = "Sleep, Unconscious"
+							"icon" = "14 44 126 130"
+					END
+					//
+					INNER_ACTION BEGIN
+						WITH_SCOPE BEGIN
 							COPY_EXISTING "%subspell%.spl" "override"
 								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+								LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END // a brand new icon would probably be better...
 							BUT_ONLY
 						END
-					END ELSE BEGIN
-						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
-						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
 					END
-				BUT_ONLY IF_EXISTS
-			END
+				END ELSE BEGIN
+					LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" INT_VAR "effectID" = 39 END
+					LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+					LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END // a brand new icon would probably be better...
+				END
+			BUT_ONLY IF_EXISTS
 		END
+	END
 
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-		/*
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
 
-		Physical knockdown (+ Wing Buffet)
+	Physical knockdown (+ Wing Buffet)
 
-		*/
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	*/
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-		WITH_SCOPE BEGIN
-			ACTION_MATCH 1 WITH
-				GAME_IS "bgee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
-						"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
-						"%HELL_BUFFET%.spl" => ""
-						"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
-						"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
-						//
-						"ax1h16.itm" => "ax1h16" // K'logarath +4
-						"ravag01.itm" => "ravag01" // 
-					END
-				END
-				GAME_IS "bg2ee eet" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
-						"abzaway.spl" => "abzaway1"
-						"balth01.spl" => "balth01d" // Solar Stance!
-						"balth09.spl" => "balth09b" // Shadowless Kick
-						"ch3away.spl" => "ch3away2"
-						"dgwhirl.spl" => "dgwhirl1"
-						"jwwhirl.spl" => "jwwhirl1"
-						"ohbbclt0.spl" => ""
-						"%ROGUE_SET_EXPLODING_TRAP%b.spl" => "%ROGUE_SET_EXPLODING_TRAP%d"
-						"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
-						"%FAN_BLOW%.spl" => "%FAN_BLOW%a"
-						"%HELL_BUFFET%.spl" => ""
-						"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
-						"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
-						"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
-						"spwish27.spl" => "spwsh27b" // Knockback
-						"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
-						//
-						"aurstaf.itm" => "aurstaf" // Staff of the Ram +4
-						"ax1h16.itm" => "ax1h16" // K'logarath +4
-						"ravag01.itm" => "ravag01" // 
-						"staf21.itm" => "staf21" // Staff of the Ram +4
-						"staf22.itm" => "staf22" // Staff of the Ram +6
-					END
-				END
-				GAME_IS "iwdee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
-						"dgwhirl.spl" => "" // Air Elemental Whirlwind
-						"%ROGUE_SET_EXPLODING_TRAP%b.spl" => ""
-						"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
-						"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
-						"spwish27.spl" => "spwis27b"
-						"spyanc01.spl" => "" // Air Elemental Whirlwind
-					END
-				END
-				DEFAULT
-					FAIL "Game not supported"
-			END
-			ACTION_PHP_EACH "wing_buffet_list" AS "file" => "subspell" BEGIN
-				COPY_EXISTING "%file%" "override"
-					LPF "EEex_bypass_op101" END
+	WITH_SCOPE BEGIN
+		ACTION_MATCH 1 WITH
+			GAME_IS "bgee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+					"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
+					"%HELL_BUFFET%.spl" => ""
+					"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
+					"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
 					//
-					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
-						// Transfer effects onto a new SPL file (if needed)
-						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
-						//
-						PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
-							INNER_ACTION BEGIN
-								WITH_SCOPE BEGIN
-									COPY_EXISTING "%cre_resref%.cre" BEGIN
-										LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = 206 "parameter1" = "-1" "timing" = 9 STR_VAR "resource" = "%subspell%" END
-									BUT_ONLY_IF_IT_CHANGES
-								END
+					"ax1h16.itm" => "ax1h16" // K'logarath +4
+					"ravag01.itm" => "ravag01" // 
+				END
+			END
+			GAME_IS "bg2ee eet" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+					"abzaway.spl" => "abzaway1"
+					"balth01.spl" => "balth01d" // Solar Stance!
+					"balth09.spl" => "balth09b" // Shadowless Kick
+					"ch3away.spl" => "ch3away2"
+					"dgwhirl.spl" => "dgwhirl1"
+					"jwwhirl.spl" => "jwwhirl1"
+					"ohbbclt0.spl" => ""
+					"%ROGUE_SET_EXPLODING_TRAP%b.spl" => "%ROGUE_SET_EXPLODING_TRAP%d"
+					"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
+					"%FAN_BLOW%.spl" => "%FAN_BLOW%a"
+					"%HELL_BUFFET%.spl" => ""
+					"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
+					"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
+					"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
+					"spwish27.spl" => "spwsh27b" // Knockback
+					"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
+					//
+					"aurstaf.itm" => "aurstaf" // Staff of the Ram +4
+					"ax1h16.itm" => "ax1h16" // K'logarath +4
+					"ravag01.itm" => "ravag01" // 
+					"staf21.itm" => "staf21" // Staff of the Ram +4
+					"staf22.itm" => "staf22" // Staff of the Ram +6
+				END
+			END
+			GAME_IS "iwdee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+					"dgwhirl.spl" => "" // Air Elemental Whirlwind
+					"%ROGUE_SET_EXPLODING_TRAP%b.spl" => "%ROGUE_SET_EXPLODING_TRAP%d"
+					"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
+					"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
+					"spwish27.spl" => "spwsh27b"
+					"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
+				END
+			END
+			DEFAULT
+				FAIL "Game not supported"
+		END
+		ACTION_PHP_EACH "wing_buffet_list" AS "file" => "subspell" BEGIN
+			COPY_EXISTING "%file%" "override"
+				PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+					// Transfer effects onto a new SPL file (if needed)
+					LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell"
+						INT_VAR
+							"effectID" = 39
+						STR_VAR
+							"subspell_resref" = "%subspell%"
+							"string" = "Sleep, Unconscious"
+							"icon" = "14 44 126 130"
+					END
+					//
+					INNER_ACTION BEGIN
+						WITH_SCOPE BEGIN
+							COPY_EXISTING "%subspell%.spl" "override"
+								LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END // a brand new icon would probably be better...
+							BUT_ONLY
+						END
+					END
+					//
+					PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
+						INNER_ACTION BEGIN
+							WITH_SCOPE BEGIN
+								COPY_EXISTING "%cre_resref%.cre" BEGIN
+									LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = 206 "parameter1" = "-1" "timing" = 9 STR_VAR "resource" = "%subspell%" END
+								BUT_ONLY_IF_IT_CHANGES
 							END
 						END
-					END ELSE BEGIN
-						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
-						TEXT_SPRINT "file_res" "%DEST_RES%"
-						TEXT_SPRINT "file_ext" "%DEST_EXT%"
-						PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
-							INNER_ACTION BEGIN
-								WITH_SCOPE BEGIN
-									COPY_EXISTING "%cre_resref%.cre" BEGIN
-										LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = ("%file_ext%" STR_EQ "SPL" ? 206 : 318) "parameter1" = ("%file_ext%" STR_EQ "SPL" ? "-1" : 0) "timing" = 9 STR_VAR "resource" = "%file_res%" END
-									BUT_ONLY_IF_IT_CHANGES
-								END
+					END
+				END ELSE BEGIN
+					LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" INT_VAR "effectID" = 39 END
+					LPF "BYPASS_OP101" INT_VAR "slpIcon" = 130 END // a brand new icon would probably be better...
+					TEXT_SPRINT "file_res" "%DEST_RES%"
+					TEXT_SPRINT "file_ext" "%DEST_EXT%"
+					PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
+						INNER_ACTION BEGIN
+							WITH_SCOPE BEGIN
+								COPY_EXISTING "%cre_resref%.cre" BEGIN
+									LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = ("%file_ext%" STR_EQ "SPL" ? 206 : 318) "parameter1" = ("%file_ext%" STR_EQ "SPL" ? "-1" : 0) "timing" = 9 STR_VAR "resource" = "%file_res%" END
+								BUT_ONLY_IF_IT_CHANGES
 							END
 						END
 					END
-				BUT_ONLY IF_EXISTS
-			END
+				END
+			BUT_ONLY IF_EXISTS
 		END
+	END
 
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
-		/*
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	/*
 
-		Unconscious (nausea)
+	Unconscious (nausea)
 
-		*/
-		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+	*/
+	/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-		WITH_SCOPE BEGIN
-			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
-				"GENERAL" , "WEAPON" => 103
-				"GENERAL" , "UNDEAD" => 103
-				"GENERAL" , "PLANT" => 103
-				//
-				"RACE" , "GOLEM" => 104
-				"RACE" , "ELEMENTAL" => 104
-				//
-				"CLASS" , "GREEN_DRAGON" => 105
+	WITH_SCOPE BEGIN
+		ACTION_DEFINE_ASSOCIATIVE_ARRAY "op39_overhaul_reserved_hash" BEGIN
+			"GENERAL" , "WEAPON" => 103 // reason: Mordenkainen's Sword (does not breathe)
+			"GENERAL" , "UNDEAD" => 103 // reason: do not breathe
+			"GENERAL" , "PLANT" => 103 // reason: do not breathe
+			//
+			"RACE" , "GOLEM" => 104 // reason: do not breathe
+			"RACE" , "ELEMENTAL" => 104 // reason: do not breathe
+			//
+			"CLASS" , "GREEN_DRAGON" => 105 // reason: they breathe, but are supposed to be immune to poison-like-based attacks
+		END
+		ACTION_MATCH 1 WITH
+			GAME_IS "bgee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+					"%MEPHIT_STINKING_CLOUD%.spl" => ""
+					"%TRAP_STINKING_CLOUD%.spl" => ""
+					"%WIZARD_STINKING_CLOUD%.spl" => ""
+					"spwm187.spl" => "" // Stinking Cloud (wild magic)
+				END
 			END
-			ACTION_MATCH 1 WITH
-				GAME_IS "bgee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
-						"%MEPHIT_STINKING_CLOUD%.spl" => ""
-						"%TRAP_STINKING_CLOUD%.spl" => ""
-						"%WIZARD_STINKING_CLOUD%.spl" => ""
-						"spwm187.spl" => "" // Stinking Cloud (wild magic)
-					END
+			GAME_IS "bg2ee eet" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+					"ohdmask.spl" => "ohdmask2" // Breath Acid
+					"ohrgrog.spl" => "ohrgrog2"
+					"%MEPHIT_STINKING_CLOUD%.spl" => ""
+					"%TRAP_STINKING_CLOUD%.spl" => ""
+					"%WIZARD_STINKING_CLOUD%.spl" => ""
+					"spwm187.spl" => "" // Stinking Cloud (wild magic)
 				END
-				GAME_IS "bg2ee eet" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
-						"ohdmask.spl" => "ohdmask2" // Breath Acid
-						"ohrgrog.spl" => "ohrgrog2"
-						"%MEPHIT_STINKING_CLOUD%.spl" => ""
-						"%TRAP_STINKING_CLOUD%.spl" => ""
-						"%WIZARD_STINKING_CLOUD%.spl" => ""
-						"spwm187.spl" => "" // Stinking Cloud (wild magic)
-					END
-				END
-				GAME_IS "iwdee" BEGIN
-					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
-						"%INNATE_ZOMBIE_LORD_AURA%.spl" => ""
-						"%TRAP_STINKING_CLOUD%.spl" => ""
-						"%WIZARD_STINKING_CLOUD%.spl" => ""
-						"spwm187.spl" => "" // Stinking Cloud (wild magic)
-					END
-				END
-				DEFAULT
-					FAIL "Game not supported"
 			END
-			ACTION_PHP_EACH "nausea_list" AS "file" => "subspell" BEGIN
-				COPY_EXISTING "%file%" "override"
-					LPF "EEex_bypass_op101" END
+			GAME_IS "iwdee" BEGIN
+				ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+					"%INNATE_ZOMBIE_LORD_AURA%.spl" => ""
+					"%TRAP_STINKING_CLOUD%.spl" => ""
+					"%WIZARD_STINKING_CLOUD%.spl" => ""
+					"spwm187.spl" => "" // Stinking Cloud (wild magic)
+				END
+			END
+			DEFAULT
+				FAIL "Game not supported"
+		END
+		ACTION_PHP_EACH "nausea_list" AS "file" => "subspell" BEGIN
+			COPY_EXISTING "%file%" "override"
+				PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+					// Transfer effects onto a new SPL file (if needed)
+					LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell"
+						INT_VAR
+							"effectID" = 39
+						STR_VAR
+							"subspell_resref" = "%subspell%"
+							"string" = "Sleep, Unconscious"
+							"icon" = "14 44 126 130"
+					END
 					//
-					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
-						// Transfer effects onto a new SPL file (if needed)
-						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
-						//
-						INNER_ACTION BEGIN
+					INNER_ACTION BEGIN
+						WITH_SCOPE BEGIN
 							COPY_EXISTING "%subspell%.spl" "override"
 								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+								LPF "BYPASS_OP101" INT_VAR "slpIcon" = 126 END
 							BUT_ONLY
 						END
-					END ELSE BEGIN
-						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
-						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
 					END
-				BUT_ONLY IF_EXISTS
-			END
+				END ELSE BEGIN
+					LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" INT_VAR "effectID" = 39 END
+					LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+					LPF "BYPASS_OP101" INT_VAR "slpIcon" = 126 END
+				END
+			BUT_ONLY IF_EXISTS
 		END
 	END
 END
@@ -448,7 +495,9 @@ Helper functions
 */
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-DEFINE_PATCH_FUNCTION "EEex_bypass_op101"
+DEFINE_PATCH_FUNCTION "BYPASS_OP101"
+INT_VAR
+	"slpIcon" = "-1"
 BEGIN
 	PATCH_MATCH "%DEST_EXT%" WITH
 		"itm" BEGIN
@@ -465,9 +514,67 @@ BEGIN
 		PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
 			PATCH_MATCH SHORT_AT "%fx_off%" WITH
 				39 BEGIN
-					WRITE_LONG ("%fx_off%" + 0x24) (THIS | BIT23) // https://github.com/Bubb13/EEex/pull/61
+					PATCH_IF (MOD_IS_INSTALLED "EEex.tp2" 0) BEGIN
+						WRITE_LONG ("%fx_off%" + 0x24) (THIS | BIT23) // see "https://github.com/Bubb13/EEex/pull/61"
+						WRITE_LONG ("%fx_off%" + 0x2C) "%splIcon%"
+					END ELSE BEGIN
+						WRITE_SHORT "%fx_off%" 177 // Use EFF file
+						WRITE_LONG ("%fx_off%" + 0x4) 0 // ANYONE
+						WRITE_LONG ("%fx_off%" + 0x8) 2 // EA.IDS
+						PATCH_MATCH "%slpIcon%" WITH
+							14 BEGIN
+								WRITE_ASCII ("%fx_off%" + 0x14) "#slp01a" #8
+								TEXT_SPRINT "slpResRef" "#slp01"
+							END
+							44 BEGIN
+								WRITE_ASCII ("%fx_off%" + 0x14) "#slp02a" #8
+								TEXT_SPRINT "slpResRef" "#slp02"
+							END
+							126 BEGIN
+								WRITE_ASCII ("%fx_off%" + 0x14) "#slp03a" #8
+								TEXT_SPRINT "slpResRef" "#slp03"
+							END
+							130 BEGIN
+								WRITE_ASCII ("%fx_off%" + 0x14) "#slp04a" #8
+								TEXT_SPRINT "slpResRef" "#slp04"
+							END
+							DEFAULT
+								PATCH_FAIL "Unexpected Sleep icon"
+						END
+						WRITE_LONG ("%fx_off%" + 0x2C) 0 // blank 'special' field
+					END
+				END
+				142 BEGIN
+					PATCH_MATCH LONG_AT ("%fx_off%" + 0x8) WITH
+						14 44 126 130 BEGIN
+							WRITE_SHORT "%fx_off%" 999 // mark it for later deletion
+						END
+						DEFAULT
+					END
 				END
 				DEFAULT
+			END
+		END
+		//
+		LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 999 END
+	END
+	//
+	PATCH_IF !(MOD_IS_INSTALLED "EEex.tp2" 0) BEGIN
+		PATCH_IF !(FILE_EXISTS_IN_GAME "%slpResRef%a.eff") BEGIN
+			INNER_ACTION BEGIN
+				CREATE "eff" "%slpResRef%a"
+					WRITE_LONG 0x10 182 // Use EFF while ITM
+					WRITE_SHORT 0x2C 100 // probability1
+					WRITE_ASCII 0x70 "%slpResRef%b" #8
+			END
+		END
+		PATCH_IF !(FILE_EXISTS_IN_GAME "%slpResRef%b.eff") BEGIN
+			INNER_ACTION BEGIN
+				CREATE "eff" "%slpResRef%b"
+					WRITE_LONG 0x10 39 // Sleep
+					WRITE_LONG 0x20 1 // Wake on Damage? No
+					WRITE_SHORT 0x2C 100 // probability1
+					WRITE_LONG 0x48 "%slpIcon%"
 			END
 		END
 	END
@@ -475,16 +582,49 @@ END
 
 DEFINE_PATCH_FUNCTION "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY"
 BEGIN
-	PHP_EACH "patch_data" AS "key" => "value" BEGIN
+	PHP_EACH "op39_overhaul_reserved_hash" AS "key" => "value" BEGIN
 		PATCH_MATCH "%DEST_EXT%" WITH
-			"SPL" WHEN (SLONG_AT NAME1 > 0) BEGIN
-				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+			"SPL" BEGIN
+				GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
 			END
-			"ITM" WHEN (LONG_AT 0x18 BAND (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE")) > 0) BEGIN
-				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+			"ITM" BEGIN
+				GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
 			END
 			DEFAULT
-				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 318 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+		END
+		//
+		PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // same for "*.spl" and "*.itm"
+			SET "found" = 0
+			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+				PATCH_MATCH SHORT_AT "%fx_off%" WITH
+					318 324 BEGIN
+						PATCH_MATCH "%key_0%" WITH
+							"PERSONAL_SPACE" WHEN (SLONG_AT ("%fx_off%" + 0x4) == 0) AND (LONG_AT ("%fx_off%" + 0x8) == 13) BEGIN
+								SET "found" = 1
+							END
+							DEFAULT
+								PATCH_IF (SLONG_AT ("%fx_off%" + 0x4) == IDS_OF_SYMBOL ("%key_0%" "%key_1%")) AND (LONG_AT ("%fx_off%" + 0x8) == "%value%") BEGIN
+									SET "found" = 1
+								END
+						END
+					END
+					DEFAULT
+				END
+			END
+			//
+			PATCH_IF !("%found%") BEGIN
+				PATCH_MATCH "%DEST_EXT%" WITH
+					"SPL" WHEN (SLONG_AT NAME1 > 0) BEGIN
+						LPF "CLONE_EFFECT" INT_VAR "header" = "%ab_ind%" "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+					END
+					"ITM" WHEN (LONG_AT 0x18 BAND (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE")) > 0) BEGIN
+						LPF "CLONE_EFFECT" INT_VAR "header" = "%ab_ind%" "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+					END
+					DEFAULT
+						LPF "CLONE_EFFECT" INT_VAR "header" = "%ab_ind%" "match_opcode" = 39 "opcode" = 318 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
+				END
+			END
 		END
 	END
 END
@@ -520,6 +660,7 @@ BEGIN
 			IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
 			IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
 			IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE")
+			// we should probably add more bulky animations, shouldn't we (see f.i. DRAGON_WHITE...?)
 				BEGIN
 					TEXT_SPRINT $"bulky_creature_list"("%DEST_RES%") ""
 				END

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -84,7 +84,7 @@ BEGIN
 				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
 					// Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header
 					SET "fx_opcode" = BYTE_AT 0x33 ? LONG_AT ("%fx_off%" + 0x10 - 0x8) : SHORT_AT "%fx_off%"
-					SET "fx_parameter2" = BYTE_AT 0x33 ? SLONG_AT ("%fx_off%" + 0x20 - 0x8) SLONG_AT ("%fx_off%" + 0x8)
+					SET "fx_parameter2" = BYTE_AT 0x33 ? SLONG_AT ("%fx_off%" + 0x20 - 0x8) : SLONG_AT ("%fx_off%" + 0x8)
 					PATCH_MATCH "%fx_opcode%" WITH
 						101 WHEN ("%fx_parameter2%" == 39) BEGIN
 							// Immunity to effect => Effect: Sleep
@@ -312,7 +312,7 @@ BEGIN
 			~ohrrage.spl~ "override" // Animal Rage
 			~ohtyr1.spl~ "override" // Exaltation
 			// ITM files
-			~gvalor1.itm~ "override" // Gauntlets of Valor
+			~gvalor1.itm~ "override" // Gauntlet of Valor (IWD:EE)
 			~amul17.itm~ "override" // Greenstone Amulet
 			~chalcy3.itm~ "override" // Greenstone Amulet
 			~helmdef.itm~ "override" // Helm of the Trusted Defender (IWD:EE)

--- a/eefixpack/files/tph/luke/op39_overhaul.tph
+++ b/eefixpack/files/tph/luke/op39_overhaul.tph
@@ -8,1106 +8,522 @@ See "https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/" for furt
 
 DEFINE_ACTION_FUNCTION "OPCODE39_OVERHAUL"
 BEGIN
-	// Initialize
-	CLEAR_ARRAYS
-	ACTION_DEFINE_ARRAY "digit" BEGIN "0" "1" "2" "3" "4" "5" "6" "7" "8" "9" END
-	ACTION_DEFINE_ARRAY "letter" BEGIN "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k" "l" "m" "n" "o" "p" "q" "r" "s" "t" "u" "v" "w" "x" "y" "z" END
-	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "SLEEP_IMMUNITY" END
-	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "NAUSEA_IMMUNITY" END
-	LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "KNOCKBACK_IMMUNITY" END
-	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "HOPELESSNESS_IMMUNITY" END // same as SLEEP_IMMUNITY ...?
-	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "UNCONSCIOUSNESS_IMMUNITY" END // same as SLEEP_IMMUNITY ...?
-	//LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "KNOCKDOWN_GROUND-BASED_IMMUNITY" END // This is probably best done via other checks (f.i. RACE=WYVERN)
+	ACTION_IF (MOD_IS_INSTALLED "EEex.tp2" 0) BEGIN
+		LAF "ADD_IDS_ENTRY" STR_VAR "idsFile" = "splstate" "identifier" = "SLEEP_IMMUNITY" END
+		LAF "GET_BULKY_CREATURES" RET_ARRAY "bulky_creature_list" END // get all creatures whose animation is hardcoded to be immune to op235 (Wing Buffet)
 
-	/*
-	==========================================================================================
-	**Opcode #39**
-	- Overall revision
-	==========================================================================================
-	*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		/*
 
-	LAF "OPCODE39_OVERHAUL#DETERMINE_SLEEP_TYPE" RET_ARRAY "sleep_resref" "earthquake_resref" END
+		Sleep / Unconscious
 
-	/*
-	========================================================================================
-	**Opcode #101 (p2==39)**
-	- The following code deals with creatures natural immunity to op39
-	========================================================================================
-	*/
+		*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	WITH_SCOPE BEGIN
-		COPY_EXISTING_REGEXP "^.+\.cre$" "override"
-			PATCH_MATCH LONG_AT 0x28 WITH
-				// The following animations are hardcoded to be immune to op235. As a result, flag them as appropriate
-				IDS_OF_SYMBOL ("ANIMATE" "TANARRI")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_RED")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLACK")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_SILVER")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_GREEN")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_AQUA")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLUE")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BROWN")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_MULTICOLOR")
-				IDS_OF_SYMBOL ("ANIMATE" "DRAGON_PURPLE")
-				IDS_OF_SYMBOL ("ANIMATE" "DEMOGORGON")
-				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_EARTH")
-				IDS_OF_SYMBOL ("ANIMATE" "SHAMBLING_MOUND")
-				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE")
-				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE_PURPLE")
-				IDS_OF_SYMBOL ("ANIMATE" "BURNING_MAN")
-				IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_AIR")
-				IDS_OF_SYMBOL ("ANIMATE" "RAVER")
-				IDS_OF_SYMBOL ("ANIMATE" "SLAYER")
-				IDS_OF_SYMBOL ("ANIMATE" "SOLAR")
-				IDS_OF_SYMBOL ("ANIMATE" "DEVA_MONADIC")
-				IDS_OF_SYMBOL ("ANIMATE" "MELISSAN")
-				IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
-				IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
-				IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE") BEGIN
-					LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "opcode" = 328 "target" = 1 "timing" = 1 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "special" = 1 END
+		WITH_SCOPE BEGIN
+			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
+				"SPLSTATE" , "SLEEP_IMMUNITY" => 110
+			END
+			ACTION_MATCH 1 WITH
+				GAME_IS "bgee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+						"bdblun07.spl" => "" // Backwhacker +2
+						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+						"bdxbow01.spl" => "" // Astral Crossbow +2
+						"spcl751a.spl" => "spcl751c" // Jester's Song
+						"%PSIONIC_MIND_BLAST%.spl" => ""
+						"%MIND_CRIPPLE%.spl" => ""
+						"%MEPHIT_COLOR_SPRAY%.spl" => ""
+						"%CLERIC_COMMAND%.spl" => ""
+						"%CLERIC_GREATER_COMMAND%.spl" => ""
+						"%WIZARD_COLOR_SPRAY%.spl" => ""
+						"%WIZARD_SLEEP%.spl" => ""
+						"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
+						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+						//
+						"bdgibbbr.itm" => "bdgibbbr" // used by "bdgibbbr.cre" (Brood Gibberling)
+						"bdspidga.itm" => "bdspidga" // used by "bdspidga.cre" (Gargantuan Spider)
+						"bdwyrmli.itm" => "bdwyrmli" // used by "bdwyrmli.cre" (Blind Albino Wyrmling)
+						"cdfampsd.itm" => ""
+						"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep +1
+						"dwdart01.itm" => "dwdart01" // Drow Dart of Sleep +1
+						"psdclaw.itm" => ""
+						"wand08.itm" => "wand08" // Wand of Sleep
+					END
+				END
+				GAME_IS "bg2ee eet" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+						"spcl751a.spl" => "spcl751c" // Jester's Song
+						"%PSIONIC_MIND_BLAST%.spl" => ""
+						"%MIND_CRIPPLE%.spl" => ""
+						"%MEPHIT_COLOR_SPRAY%.spl" => ""
+						"%CLERIC_COMMAND%.spl" => ""
+						"%CLERIC_GREATER_COMMAND%.spl" => ""
+						"%WIZARD_COLOR_SPRAY%.spl" => ""
+						"%WIZARD_SLEEP%.spl" => ""
+						"%WIZARD_EMOTION_HOPELESSNESS%.spl" => ""
+						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+						//
+						"cdfampsd.itm" => ""
+						"dagg13.itm" => "dagg13" // Pixie Prick +3
+						"dwbolt01.itm" => "dwbolt01" // Drow Bolt of Sleep
+						"ohbbrvgr.itm" => "ohbbrvgr" // used by "ohbbrvgr.cre" (The Ravager)
+						"psdclaw.itm" => ""
+						"staf15.itm" => "" // Staff of Air +2
+						"wand08.itm" => "wand08" // Wand of Sleep
+					END
+				END
+				GAME_IS "iwdee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "sleep_unconscious_list" BEGIN
+						"bdsha12c.spl" => "" // used by "bdsha12c.cre" (Lesser Earth Spirit)
+						"spcl751a.spl" => "spcl751c" // Jester's Song
+						"%INNATE_BEHOLDER_SLEEP%.spl" => ""
+						"%INNATE_JACKALWERE_GAZE_INTERNAL%.spl" => ""
+						"%MIND_CRIPPLE%.spl" => ""
+						"%CLERIC_COMMAND%.spl" => ""
+						"%CLERIC_SMASHING_WAVE%.spl" => ""
+						"%CLERIC_GREATER_COMMAND%.spl" => ""
+						"%TRAP_SLEEP%.spl" => "%TRAP_SLEEP%c"
+						"%WIZARD_COLOR_SPRAY%.spl" => ""
+						"%WIZARD_SLEEP%.spl" => ""
+						"%WIZARD_POWER_WORD_SLEEP%.spl" => ""
+						"WIZARD_SPHERE_OF_CHAOS.spl" => "%WIZARD_SPHERE_OF_CHAOS%d"
+						//
+						"cdfampsd.itm" => ""
+						"uhalb3b.itm" => "uhalb3b" // Darig's Rest +2
+						"wand08.itm" => "wand08" // Wand of Sleep
+					END
 				END
 				DEFAULT
+					FAIL "Game not supported"
 			END
-			// Check CRE effects
-			PATCH_WITH_SCOPE BEGIN
-				SET "found" = 0
-				PATCH_MATCH BYTE_AT 0x33 WITH
-					0 BEGIN
-						GET_OFFSET_ARRAY "fx_array" 0x2C4 4 0x2C8 4 0 0 0x30
-					END
-					1 BEGIN
-						GET_OFFSET_ARRAY "fx_array" CRE_V10_EFFECTS
-					END
-					DEFAULT
-						PATCH_FAIL "%DEST_FILE%: unknown effect version"
-				END
-				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-					// Unlike ordinary V2 EFF files, CRE effect V2 structures omit the 8-byte EFF V2 header
-					SET "fx_opcode" = BYTE_AT 0x33 ? LONG_AT ("%fx_off%" + 0x10 - 0x8) : SHORT_AT "%fx_off%"
-					SET "fx_parameter2" = BYTE_AT 0x33 ? SLONG_AT ("%fx_off%" + 0x20 - 0x8) : SLONG_AT ("%fx_off%" + 0x8)
-					PATCH_MATCH "%fx_opcode%" WITH
-						101 WHEN ("%fx_parameter2%" == 39) BEGIN
-							// Immunity to effect => Effect: Sleep
-							SET "found" = 1
+			ACTION_PHP_EACH "sleep_unconscious_list" AS "file" => "subspell" BEGIN
+				COPY_EXISTING "%file%" "override"
+					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+						// Transfer effects onto a new SPL file (if needed)
+						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
+						//
+						INNER_ACTION BEGIN
+							COPY_EXISTING "%subspell%.spl" "override"
+								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+							BUT_ONLY
 						END
-						DEFAULT
+					END ELSE BEGIN
+						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
+						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+					END
+				BUT_ONLY IF_EXISTS
+			END
+		END
+
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		/*
+
+		"Forced" Sleep (f.i. cutscenes, dialogs, troll/wolf-death mechanics, ...)
+
+		*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		WITH_SCOPE BEGIN
+			ACTION_MATCH 1 WITH
+				GAME_IS "bgee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+						"bdgassa1.spl" => "" // used by "bd0103.bcs" , "bd0104.bcs" , "bddausto.bcs" , "bddausto.dlg" , "bdtiax.dlg"
+						"bdgassa3.spl" => "" // unused...?
+						"bdsleep.spl" => "" // used by "bd6100.bcs" , "bdcutslp.bcs"
+						"bdtroll1.spl" => ""
+						"bdulori.spl" => ""
+						"bdwolfd1.spl" => ""
+						"shoal1.spl" => "shoal1b" // Nereid's Kiss (used by "shoal.dlg")
+						"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // unused...?
+						"%SURE_SLEEP%.spl" => "" // used by "bpfinal.bcs" , "chasel3.bcs" , "drunk.dlg"
+						"%TROLL_SLEEP%.spl" => ""
+						"trollreg.spl" => ""
+						//
+						"bddagg06.itm" => "" // Dagger +2 (used by "bdfinal[1-2].cre", "bdfinal4.cre")
+						"bddagg07.itm" => "" // Throwing Dagger +1 (used by "bdfinal3.cre", "bdfinal5.cre")
 					END
 				END
-				PATCH_IF "%found%" BEGIN
-					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
-					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
-					LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
+				GAME_IS "bg2ee eet" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+						"cdhgtrl.spl" => ""
+						"cdtorgal.spl" => ""
+						"cdtrlblz.spl" => ""
+						"ch3drain.spl" => "" // unused...?
+						"ch3flash.spl" => "" // unused...?
+						"ch3weak.spl" => "" // unused...?
+						"jwfall.spl" => "" // used by "itladr1[a-b].dlg" , "itladr2[a-b].dlg" , "itladr3[a-b].dlg"
+						"jwsleep.spl" => "" // used by "cut233g.bcs"
+						"ohddivrt.spl" => "" // used by "ohdddorl.bcs" , "ohddixth.bcs"
+						"%ABAZIGAL_SHOCKWAVE%.spl" => "%ABAZIGAL_SHOCKWAVE%b" // used by "abazdrag.bcs"
+						"%SAREVOK_SOULSTEAL%.spl" => "" // used by "cut206[a-b].bcs"
+						"%VIEKANG_LIGHTNING%.spl" => "%VIEKANG_LIGHTNING%b" // used by "sarvie01.dlg" , "viekang.dlg"
+						"%SURE_SLEEP%.spl" => "" // used by "cut28a.bcs" , "cut49a.bcs" , "cut67a.bcs" , "drunk.dlg"
+						"%TROLL_SLEEP%.spl" => ""
+						"trollreg.spl" => ""
+					END
 				END
+				GAME_IS "iwdee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "forced_sleep_list" BEGIN
+						"#jedslp.spl" => "" // used by "doldjed.dlg"
+						"cdiwdtr1.spl" => ""
+						"cdiwdtr2.spl" => ""
+						"%INNATE_RETRIBUTION%.spl" => "" // used by "bcscut2a.bcs" , "bcscut2d.bcs"
+						"%INNATE_WEREWOLF_DEATH%.spl" => ""
+						"%INNATE_WYLFDENES_DEATH_ANIMATION%.spl" => ""
+						"%INNATE_DRAGON_DEATH_ANIMATION%.spl" => ""
+						"%INNATE_POLYMORPH_TO_DOG%.spl" => ""
+						"%WIZARD_GREAT_SHOUT%.spl" => ""
+					END
+				END
+				DEFAULT
+					FAIL "Game not supported"
 			END
-			// Check CRE items
-			PATCH_WITH_SCOPE BEGIN
-				GET_OFFSET_ARRAY "itm_array" CRE_V10_ITEMS
-				PHP_EACH "itm_array" AS "itm_ind" => "itm_off" BEGIN
-					READ_ASCII ("%itm_off%" + 0x0) "itm_resref"
-					PATCH_MATCH "%itm_resref%" WITH
-						~bdbelhia~ ~demogorg~ ~behamu~ ~cibossb~ BEGIN END // Demogorgon, Belhifet, Luremaster (arbitrary boss immunities)
-						~bddraggh~ ~bdringgh~ ~sprngb02~ ~sprngb03~ ~sprngb04~ ~sprngs04~ ~sprngw01~ ~sprngs02~ "sprngw02" ~sprngw03~ ~sprngw04~ ~sprngz05~ BEGIN END // Exclusive to "Spirits/Ghosts" (Ghost Dragon, Shaman/Druid Spirits) (All Immunities - skip)
-						DEFAULT
+			ACTION_PHP_EACH "forced_sleep_list" AS "file" => "subspell" BEGIN
+				COPY_EXISTING "%file%" "override"
+					LPF "EEex_bypass_op101" END
+					//
+					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+						// Transfer effects onto a new SPL file (if needed)
+						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
+					END ELSE BEGIN
+						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
+					END
+				BUT_ONLY IF_EXISTS
+			END
+		END
+
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		/*
+
+		Physical knockdown (Earthquake)
+
+		*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		WITH_SCOPE BEGIN
+			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
+				"GENERAL" , "WEAPON" => 103
+				//
+				"RACE" , "DRAGON" => 104
+				"RACE" , "WYVERN" => 104
+				"RACE" , "DEMILICH" => 104
+				"RACE" , "HARPY" => 104
+				"RACE" , "MEPHIT" => 104
+				"RACE" , "IMP" => 104
+				"RACE" , "SPECTRAL_UNDEAD" => 104
+				"RACE" , "SPECTRE" => 104
+				"RACE" , "WRAITH" => 104
+				"RACE" , "SHADOW" => 104
+				"RACE" , "SLIME" => 104
+				"RACE" , "BEHOLDER" => 104
+				"RACE" , "FEYR" => 104
+				"RACE" , "WILL-O-WISP" => 104
+				//
+				"CLASS" , "ELEMENTAL_EARTH" => 105
+				//
+				"PERSONAL_SPACE" , "" => 13 // PERSONALSPACE>3 (this is inherited from iwdee)
+			END
+			ACTION_MATCH 1 WITH
+				GAME_IS "bgee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+						"bpgiaqke.spl" => ""
+						"spogre01.spl" => "spogre03" // Earthquake
+						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
+					END
+				END
+				GAME_IS "bg2ee eet" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+						"jwsiege.spl" => "jwsiege2"
+						"ohbquake.spl" => "ohbquak2" // Earthquake
+						"spogre01.spl" => "spogre03" // Earthquake
+						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
+						//
+						"sper12.itm" => "sper12" // Ixil's Spike +6 (consider this as a special, edge-case earthquake)
+					END
+				END
+				GAME_IS "iwdee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "earthquake_list" BEGIN
+						"spogre01.spl" => "spogre03"
+						"%CLERIC_EARTHQUAKE%.spl" => "%CLERIC_EARTHQUAKE%b"
+					END
+				END
+				DEFAULT
+					FAIL "Game not supported"
+			END
+			ACTION_PHP_EACH "earthquake_list" AS "file" => "subspell" BEGIN
+				COPY_EXISTING "%file%" "override"
+					LPF "EEex_bypass_op101" END
+					//
+					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+						// Transfer effects onto a new SPL file (if needed)
+						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
+						//
+						INNER_ACTION BEGIN
+							COPY_EXISTING "%subspell%.spl" "override"
+								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+							BUT_ONLY
+						END
+					END ELSE BEGIN
+						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
+						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+					END
+				BUT_ONLY IF_EXISTS
+			END
+		END
+
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		/*
+
+		Physical knockdown (+ Wing Buffet)
+
+		*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+		WITH_SCOPE BEGIN
+			ACTION_MATCH 1 WITH
+				GAME_IS "bgee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+						"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
+						"%HELL_BUFFET%.spl" => ""
+						"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
+						"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
+						//
+						"ax1h16.itm" => "ax1h16" // K'logarath +4
+						"ravag01.itm" => "ravag01" // 
+					END
+				END
+				GAME_IS "bg2ee eet" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+						"abzaway.spl" => "abzaway1"
+						"balth01.spl" => "balth01d" // Solar Stance!
+						"balth09.spl" => "balth09b" // Shadowless Kick
+						"ch3away.spl" => "ch3away2"
+						"dgwhirl.spl" => "dgwhirl1"
+						"jwwhirl.spl" => "jwwhirl1"
+						"ohbbclt0.spl" => ""
+						"%ROGUE_SET_EXPLODING_TRAP%b.spl" => "%ROGUE_SET_EXPLODING_TRAP%d"
+						"%PSIONIC_PROJECT_FORCE%.spl" => "%PSIONIC_PROJECT_FORCE%a"
+						"%FAN_BLOW%.spl" => "%FAN_BLOW%a"
+						"%HELL_BUFFET%.spl" => ""
+						"%DRAGON_WING_BUFFET%.spl" => "%DRAGON_WING_BUFFET%b"
+						"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
+						"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
+						"spwish27.spl" => "spwsh27b" // Knockback
+						"spyanc01.spl" => "spyanc03" // Air Elemental Whirlwind
+						//
+						"aurstaf.itm" => "aurstaf" // Staff of the Ram +4
+						"ax1h16.itm" => "ax1h16" // K'logarath +4
+						"ravag01.itm" => "ravag01" // 
+						"staf21.itm" => "staf21" // Staff of the Ram +4
+						"staf22.itm" => "staf22" // Staff of the Ram +6
+					END
+				END
+				GAME_IS "iwdee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "wing_buffet_list" BEGIN
+						"dgwhirl.spl" => "" // Air Elemental Whirlwind
+						"%ROGUE_SET_EXPLODING_TRAP%b.spl" => ""
+						"%WIZARD_DRAGONS_BREATH%.spl" => "%WIZARD_DRAGONS_BREATH%b"
+						"%WIZARD_COMET%.spl" => "%WIZARD_COMET%b"
+						"spwish27.spl" => "spwis27b"
+						"spyanc01.spl" => "" // Air Elemental Whirlwind
+					END
+				END
+				DEFAULT
+					FAIL "Game not supported"
+			END
+			ACTION_PHP_EACH "wing_buffet_list" AS "file" => "subspell" BEGIN
+				COPY_EXISTING "%file%" "override"
+					LPF "EEex_bypass_op101" END
+					//
+					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+						// Transfer effects onto a new SPL file (if needed)
+						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
+						//
+						PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
 							INNER_ACTION BEGIN
-								COPY_EXISTING "%itm_resref%.itm" "override"
-									PATCH_IF ((BYTE_AT 0x18) BAND IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE")) BEGIN
-										// Skip droppable (player) items
-									END ELSE BEGIN
-										// Undroppable creature skin
-										SET "found_101#39" = 0
-										SET "revive_spl" = 0
-										GET_OFFSET_ARRAY "fx_array" ITM_V10_GEN_EFFECTS
-										PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-											PATCH_MATCH SHORT_AT "%fx_off%" WITH
-												101 WHEN (SLONG_AT ("%fx_off%" + 0x8) == 39) BEGIN
-													SET "found_101#39" = 1
-												END
-												98 BEGIN // Regeneration
-													SET "revive_spl" += 1
-												END
-												232 BEGIN // Cast spell on condition
-													PATCH_MATCH SLONG_AT ("%fx_off%" + 0x8) WITH
-														2 3 4 19 20 BEGIN // HP-related triggers
-															SET "revive_spl" += 1
-														END
-														DEFAULT
-													END
-												END
-												DEFAULT
-											END
-										END
-										PATCH_IF "%found_101#39%" BEGIN
-											PATCH_MATCH "%revive_spl%" WITH
-												2 BEGIN
-													PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-														PATCH_MATCH SHORT_AT "%fx_off%" WITH
-															267 BEGIN // Disable display string
-																LPF "GT_GET_STRING" INT_VAR "strref" = SLONG_AT ("%fx_off%" + 0x4) RET "string" END
-																PATCH_MATCH "%string%" WITH
-																	"Sleep" BEGIN
-																		WRITE_SHORT "%fx_off%" 998
-																	END
-																	DEFAULT
-																END
-															END
-															DEFAULT
-														END
-													END
-													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 998 END
-													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 END // Sleep
-													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 217 END // Power word, sleep
-												END
-												DEFAULT
-													LPF "CLONE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
-													LPF "CLONE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
-													LPF "DELETE_EFFECT" INT_VAR "check_headers" = 0 "match_opcode" = 101 "match_parameter2" = 39 END
-											END
-										END
-									END
-								BUT_ONLY IF_EXISTS
+								WITH_SCOPE BEGIN
+									COPY_EXISTING "%cre_resref%.cre" BEGIN
+										LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = 206 "parameter1" = "-1" "timing" = 9 STR_VAR "resource" = "%subspell%" END
+									BUT_ONLY_IF_IT_CHANGES
+								END
 							END
-					END
-				END
-			END
-		BUT_ONLY_IF_IT_CHANGES
-	END
-
-	/*
-	====================================================================================================================================================================
-	**Opcode #101 (p2==39)**
-	- Polymorph-related ITMs
-	====================================================================================================================================================================
-	*/
-
-	WITH_SCOPE BEGIN
-		COPY_EXISTING_REGEXP "^.+\.itm$" "override"
-			SET "found_101#39" = 0
-			SET "found_135" = 0
-			GET_OFFSET_ARRAY "fx_array" ITM_V10_GEN_EFFECTS
-			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-				PATCH_MATCH SHORT_AT "%fx_off%" WITH
-					101 WHEN (SLONG_AT ("%fx_off%" + 0x8) == 39) BEGIN
-						SET "found_101#39" = 1
-					END
-					135 BEGIN
-						READ_ASCII ("%fx_off%" + 0x14) "cre_resref"
-						SET "found_135" = 1
-					END
-					DEFAULT
-				END
-			END
-			// 
-			PATCH_IF "%found_135%" BEGIN
-				SET "immunize_against_knockback" = 0
-				SET "immunize_against_earthquake" = 0
-				INNER_PATCH_FILE "%cre_resref%.cre" BEGIN
-					PATCH_MATCH LONG_AT 0x28 WITH
-						// The following animations are hardcoded to be immune to op235
-						IDS_OF_SYMBOL ("ANIMATE" "TANARRI")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_RED")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLACK")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_SILVER")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_GREEN")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_AQUA")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLUE")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BROWN")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_MULTICOLOR")
-						IDS_OF_SYMBOL ("ANIMATE" "DRAGON_PURPLE")
-						IDS_OF_SYMBOL ("ANIMATE" "DEMOGORGON")
-						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_EARTH")
-						IDS_OF_SYMBOL ("ANIMATE" "SHAMBLING_MOUND")
-						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE")
-						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE_PURPLE")
-						IDS_OF_SYMBOL ("ANIMATE" "BURNING_MAN")
-						IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_AIR")
-						IDS_OF_SYMBOL ("ANIMATE" "RAVER")
-						IDS_OF_SYMBOL ("ANIMATE" "SLAYER")
-						IDS_OF_SYMBOL ("ANIMATE" "SOLAR")
-						IDS_OF_SYMBOL ("ANIMATE" "DEVA_MONADIC")
-						IDS_OF_SYMBOL ("ANIMATE" "MELISSAN")
-						IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
-						IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
-						IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE") BEGIN
-							SET "immunize_against_knockback" = 1
 						END
-						DEFAULT
-					END
-					PATCH_MATCH BYTE_AT 0x271 WITH
-						IDS_OF_SYMBOL ("GENERAL" "UNDEAD") BEGIN
-							SET "immunize_against_earthquake" = 1
+					END ELSE BEGIN
+						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
+						TEXT_SPRINT "file_res" "%DEST_RES%"
+						TEXT_SPRINT "file_ext" "%DEST_EXT%"
+						PHP_EACH "bulky_creature_list" AS "cre_resref" => "" BEGIN
+							INNER_ACTION BEGIN
+								WITH_SCOPE BEGIN
+									COPY_EXISTING "%cre_resref%.cre" BEGIN
+										LPF "ADD_CRE_EFFECT" INT_VAR "insert_point" = "-1" "target" = 1 "opcode" = ("%file_ext%" STR_EQ "SPL" ? 206 : 318) "parameter1" = ("%file_ext%" STR_EQ "SPL" ? "-1" : 0) "timing" = 9 STR_VAR "resource" = "%file_res%" END
+									BUT_ONLY_IF_IT_CHANGES
+								END
+							END
 						END
-						DEFAULT
 					END
-					PATCH_MATCH BYTE_AT 0x272 WITH
-						IDS_OF_SYMBOL ("RACE" "WYVERN")
-						IDS_OF_SYMBOL ("RACE" "BEHOLDER")
-						IDS_OF_SYMBOL ("RACE" "HARPY")
-						IDS_OF_SYMBOL ("RACE" "IMP")
-						IDS_OF_SYMBOL ("RACE" "MEPHIT")
-						IDS_OF_SYMBOL ("RACE" "DRAGON")
-						IDS_OF_SYMBOL ("RACE" "DEMILICH")
-						IDS_OF_SYMBOL ("RACE" "SHADOW")
-						IDS_OF_SYMBOL ("RACE" "SPECTRE")
-						IDS_OF_SYMBOL ("RACE" "WRAITH")
-						IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD")
-						IDS_OF_SYMBOL ("RACE" "WILL-O-WISP")
-						IDS_OF_SYMBOL ("RACE" "SLIME")
-						IDS_OF_SYMBOL ("RACE" "MIST") BEGIN
-							SET "immunize_against_earthquake" = 1
-						END
-						DEFAULT
-					END
-					PATCH_MATCH BYTE_AT 0x273 WITH
-						IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH")
-						IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") BEGIN
-							SET "immunize_against_earthquake" = 1
-						END
-						DEFAULT
-					END
-				END
-				// 
-				PATCH_IF "%immunize_against_knockback%" BEGIN
-					LPF "ADD_ITEM_EQEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 328 "target" = 1 "timing" = 2 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "special" = 1 END
-				END
-				PATCH_IF "%immunize_against_earthquake%" BEGIN
-					PHP_EACH "earthquake_resref" AS "resource" => "" BEGIN
-						LPF "ADD_ITEM_EQEFFECT" INT_VAR "insert_point" = "-1" "opcode" = 318 "target" = 1 "timing" = 2 STR_VAR "resource" END
-					END
-				END
-				// 
-				PATCH_IF "%found_101#39%" BEGIN
-					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 END
-					LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "multi_match" = 1 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 END
-					LPF "DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
-				END
+				BUT_ONLY IF_EXISTS
 			END
-		BUT_ONLY_IF_IT_CHANGES
-	END
+		END
 
-	/*
-	====================================================================================================================================================================
-	**Opcode #101 (p2==39)**
-	- Everything below here is for Player SPLs/ITMs intended to block specific effects regardless of the recipient, each has to be manually specified (for best results)
-	====================================================================================================================================================================
-	*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
+		/*
 
-	// IMM: Mind-affecting
+		Unconscious (nausea)
 
-	WITH_SCOPE BEGIN
-		COPY_EXISTING
-			// SPL files
-			~%CLERIC_EXALTATION%.spl~ "override"
-			~%CLERIC_BLOOD_RAGE%.spl~ "override"
-			~%CLERIC_CHAOTIC_COMMANDS%.spl~ "override"
-			~%CLERIC_IMPERVIOUS_SANCTITY_OF_MIND%.spl~ "override"
-			~%WIZARD_MIND_BLANK%.spl~ "override"
-			~%MINSC_BERSERK%.spl~ "override"
-			~%SLAYER_ENEMY%.spl~ "override"
-			~%SLAYER_CHANGE_TWO%.spl~ "override"
-			~%SLAYER_CHANGE%.spl~ "override"
-			~%THREE_ROUND_ENCHANTMENT_IMMUNITY%.spl~ "override"
-			~%FIVE_ROUND_ENCHANTMENT_IMMUNITY%.spl~ "override"
-			~%BARBARIAN_RAGE%.spl~ "override"
-			~%BERSERKER_RAGE%.spl~ "override"
-			~ohrrage.spl~ "override" // Animal Rage
-			~ohtyr1.spl~ "override" // Exaltation
-			// ITM files
-			~gvalor1.itm~ "override" // Gauntlet of Valor (IWD:EE)
-			~amul17.itm~ "override" // Greenstone Amulet
-			~chalcy3.itm~ "override" // Greenstone Amulet
-			~helmdef.itm~ "override" // Helm of the Trusted Defender (IWD:EE)
-				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
-				LPF	"DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
-		BUT_ONLY IF_EXISTS
-	END
+		*/
+		/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-	// IMM: Mind-affecting, Nausea
-
-	WITH_SCOPE BEGIN
-		COPY_EXISTING
-			// SPL files
-			~ohbbanno.spl~ "override" // Iron Golem Transformation
-			// ITM files
-				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
-				LPF	"CLONE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 "opcode" = 328 "parameter1" = 0 "parameter2" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "special" = 1 STR_VAR "resource" = ~~ END
-				LPF	"DELETE_EFFECT" INT_VAR "match_opcode" = 101 "match_parameter2" = 39 END
-		BUT_ONLY IF_EXISTS
-	END
-
-	/*
-	==============================================================================================================================================================
-	**Opcode #2 (Cure Sleep)**
-	- Everything below here is for SPLs/ITMs intended to remove specific effects regardless of the recipient, each has to be manually specified (for best results)
-	==============================================================================================================================================================
-	*/
-
-	WITH_SCOPE BEGIN
-		COPY_EXISTING "#cureslp.spl" "override"
-			PHP_EACH "sleep_resref" AS "resource" => "" BEGIN
-				LPF	"CLONE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 2 "opcode" = 321 "parameter1" = 0 "parameter2" = 2 "special" = 0 STR_VAR "resource" END
+		WITH_SCOPE BEGIN
+			ACTION_DEFINE_ASSOCIATIVE_ARRAY "patch_data" BEGIN
+				"GENERAL" , "WEAPON" => 103
+				"GENERAL" , "UNDEAD" => 103
+				"GENERAL" , "PLANT" => 103
+				//
+				"RACE" , "GOLEM" => 104
+				"RACE" , "ELEMENTAL" => 104
+				//
+				"CLASS" , "GREEN_DRAGON" => 105
 			END
-			LPF	"DELETE_EFFECT" INT_VAR "check_globals" = 0 "match_opcode" = 2 END
-		BUT_ONLY_IF_IT_CHANGES
+			ACTION_MATCH 1 WITH
+				GAME_IS "bgee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+						"%MEPHIT_STINKING_CLOUD%.spl" => ""
+						"%TRAP_STINKING_CLOUD%.spl" => ""
+						"%WIZARD_STINKING_CLOUD%.spl" => ""
+						"spwm187.spl" => "" // Stinking Cloud (wild magic)
+					END
+				END
+				GAME_IS "bg2ee eet" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+						"ohdmask.spl" => "ohdmask2" // Breath Acid
+						"ohrgrog.spl" => "ohrgrog2"
+						"%MEPHIT_STINKING_CLOUD%.spl" => ""
+						"%TRAP_STINKING_CLOUD%.spl" => ""
+						"%WIZARD_STINKING_CLOUD%.spl" => ""
+						"spwm187.spl" => "" // Stinking Cloud (wild magic)
+					END
+				END
+				GAME_IS "iwdee" BEGIN
+					ACTION_DEFINE_ASSOCIATIVE_ARRAY "nausea_list" BEGIN
+						"%INNATE_ZOMBIE_LORD_AURA%.spl" => ""
+						"%TRAP_STINKING_CLOUD%.spl" => ""
+						"%WIZARD_STINKING_CLOUD%.spl" => ""
+						"spwm187.spl" => "" // Stinking Cloud (wild magic)
+					END
+				END
+				DEFAULT
+					FAIL "Game not supported"
+			END
+			ACTION_PHP_EACH "nausea_list" AS "file" => "subspell" BEGIN
+				COPY_EXISTING "%file%" "override"
+					LPF "EEex_bypass_op101" END
+					//
+					PATCH_IF ("%subspell%" STRING_COMPARE_CASE "") BEGIN
+						// Transfer effects onto a new SPL file (if needed)
+						LAUNCH_PATCH_FUNCTION "gt_extract_effects_as_subspell" INT_VAR "effectID" = 39 STR_VAR "subspell_resref" = "%subspell%" END
+						//
+						INNER_ACTION BEGIN
+							COPY_EXISTING "%subspell%.spl" "override"
+								LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+							BUT_ONLY
+						END
+					END ELSE BEGIN
+						LAUNCH_PATCH_FUNCTION "gt_reorder_effect_stack" END
+						LPF "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY" END
+					END
+				BUT_ONLY IF_EXISTS
+			END
+		END
 	END
 END
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*
 
 Helper functions
 
 */
-////////////////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-DEFINE_ACTION_FUNCTION "OPCODE39_OVERHAUL#DETERMINE_SLEEP_TYPE"
-RET_ARRAY
-	"sleep_resref"
-	"earthquake_resref"
+DEFINE_PATCH_FUNCTION "EEex_bypass_op101"
 BEGIN
-	COPY_EXISTING_REGEXP "^.+\.\(itm\|spl\)$" "override"
-		PATCH_MATCH "%DEST_EXT%" WITH
-			"ITM" BEGIN
-				GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
-			END
-			"SPL" BEGIN
-				GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
-			END
-			DEFAULT
-				PATCH_FAIL "'%DEST_FILE%': unexpected file!"
+	PATCH_MATCH "%DEST_EXT%" WITH
+		"itm" BEGIN
+			GET_OFFSET_ARRAY "ab_array" ITM_V10_HEADERS
 		END
-		PATCH_CLEAR_ARRAY "fx_match"
-		TEXT_SPRINT "file_ext" "%DEST_EXT%" // keep a copy of original "%DEST_EXT%"
-		TEXT_SPRINT "file_res" "%DEST_RES%" // keep a copy of original "%DEST_RES%"
-		// Make sure troll / wolf revive spl files target '1|Self'
-		PATCH_MATCH "%file_res%" WITH
-			"bdwolfd1" "bdtroll1" BEGIN // wolf / troll revive spl files
-				LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "target" = 1 END
-			END
-			DEFAULT
-		END
-		// Record all op39 effects
-		PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
-			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
-			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-				// Take note of current effect's attributes
-				READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
-				READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
-				READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
-				READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
-				READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
-				READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
-				READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
-				READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
-				READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
-				READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
-				READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
-				READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
-				READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
-				READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
-				READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
-				READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
-				// Skip Self-targeted effects (that is to say, skip the various troll revive SPL files, WIZARD_GREATE_SHOUT, etc...)
-				PATCH_IF ("%ITMSPL_effect_opcode%" == 39) AND ("%ITMSPL_effect_target%" != 1) BEGIN
-					PATCH_MATCH "%ITMSPL_effect_timing%" WITH
-						1 2 5 6 7 8 9 BEGIN END // Ignore permanent and invalid timing modes
-						DEFAULT
-							DEFINE_ASSOCIATIVE_ARRAY "fx_match" BEGIN
-								"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "%ab_ind%" , "%fx_ind%" => ""
-							END
-							WRITE_SHORT "%fx_off%" 999 // mark it for later detection
-					END
-				END
-			END
-		END
-		// 
-		SET "is_op39_on_all_abilities" = 0
-		PHP_EACH "fx_match" AS "fx_match_attribute" => "" BEGIN
-			PATCH_IF ("%fx_match_attribute_16%" == (SHORT_AT 0x68) - 1) BEGIN // Ability count starts from 0 (that is to say, the 1st Ability is Ability #0)
-				SET "is_op39_on_all_abilities" = 1
-			END
-		END
-		// For each op39 found, get its ancillary effects (if any)
-		PHP_EACH "fx_match" AS "fx_match_attribute" => "" BEGIN
-			// Initialize
-			SET "non-cosmetic_effects" = 0 // Suppose there are no non-cosmetic effects
-			SET "racial_sleep_immunity" = 0
-			TEXT_SPRINT "sleep_type" "Unconsciousness"
-			SET "ab_off" = ("%file_ext%" STR_EQ "ITM") ? LONG_AT 0x64 + ("%fx_match_attribute_16%" * 0x38) : LONG_AT 0x64 + ("%fx_match_attribute_16%" * 0x28)
-			SET "ab_ind" = "%fx_match_attribute_16%"
-			PATCH_CLEAR_ARRAY "fx_ancillary"
-			// Main
-			GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
-			PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-				// Take note of current effect's attributes
-				READ_SHORT ("%fx_off%" + 0x0) "ITMSPL_effect_opcode"
-				READ_BYTE ("%fx_off%" + 0x2) "ITMSPL_effect_target"
-				READ_BYTE ("%fx_off%" + 0x3) "ITMSPL_effect_power"
-				READ_SLONG ("%fx_off%" + 0x4) "ITMSPL_effect_parameter1"
-				READ_SLONG ("%fx_off%" + 0x8) "ITMSPL_effect_parameter2"
-				READ_BYTE ("%fx_off%" + 0xC) "ITMSPL_effect_timing"
-				READ_BYTE ("%fx_off%" + 0xD) "ITMSPL_effect_resist_dispel"
-				READ_LONG ("%fx_off%" + 0xE) "ITMSPL_effect_duration"
-				READ_BYTE ("%fx_off%" + 0x12) "ITMSPL_effect_probability1"
-				READ_BYTE ("%fx_off%" + 0x13) "ITMSPL_effect_probability2"
-				READ_ASCII ("%fx_off%" + 0x14) "ITMSPL_effect_resource"
-				READ_LONG ("%fx_off%" + 0x1C) "ITMSPL_effect_dicenumber"
-				READ_LONG ("%fx_off%" + 0x20) "ITMSPL_effect_dicesize"
-				READ_LONG ("%fx_off%" + 0x24) "ITMSPL_effect_savingthrow"
-				READ_SLONG ("%fx_off%" + 0x28) "ITMSPL_effect_savebonus"
-				READ_SLONG ("%fx_off%" + 0x2C) "ITMSPL_effect_special"
-				// 
-				PATCH_MATCH "%ITMSPL_effect_opcode%" WITH
-					999 BEGIN
-						PATCH_MATCH "%ITMSPL_effect_special%" WITH
-							126 BEGIN
-								TEXT_SPRINT "sleep_type" "Nausea"
-							END
-							DEFAULT
-						END
-						/*PATCH_IF ("%ITMSPL_effect_duration%" < 6) BEGIN
-							TEXT_SPRINT "sleep_type" "Knockback"
-						END*/
-					END
-					39 WHEN ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") AND ("%ITMSPL_effect_parameter1%" == "%fx_match_attribute_3%") AND ("%ITMSPL_effect_parameter2%" == "%fx_match_attribute_4%") BEGIN END // skip subspell in case of multiple op39 effects of the same type
-					7 8 9 41 50 51 52 61 141 215 BEGIN // Visual effects (since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-												"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-											END
-											WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-										END
-									END
-								END
-							END
-						END
-					END
-					139 BEGIN // Display string
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
-													PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
-														PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
-															// WeiDU's GET_STRREF is language-dependant, so we need to fetch the corresponding string from the english version of "dialog.tlk"
-															LPF "GT_GET_STRING" INT_VAR "strref" = "%ITMSPL_effect_parameter1%" RET "string" END
-															PATCH_MATCH "%string%" WITH
-																"Sleep" "Unconscious" "Too high level for Color Spray" BEGIN
-																	DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																		"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																	END
-																	WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-																END
-																DEFAULT
-																	SET "non-cosmetic_effects" = 1
-															END
-														END
-													END
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					142 BEGIN // Display portrait icon
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-													PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
-														PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
-															PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
-																PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
-																	PATCH_MATCH "%ITMSPL_effect_parameter2%" WITH
-																		14 44 130 BEGIN // Sleep Hopelessness Unconscious
-																			DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																				"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																			END
-																			WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-																		END
-																		126 BEGIN // Nauseated
-																			DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																				"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																			END
-																			WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-																			TEXT_SPRINT "sleep_type" "Nausea"
-																		END
-																		DEFAULT
-																			SET "non-cosmetic_effects" = 1
-																	END
-																END
-															END
-														END
-													END
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					174 WHEN ("%ITMSPL_effect_timing%" == 1) BEGIN // Play sound (initial sound - since these are just cosmetic effects, don't bother checking for Min/Max level and Savetype/Savebonus ...)
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-									PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-										PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-											DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-												"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-											END
-											WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-										END
-									END
-								END
-							END
-						END
-					END
-					174 WHEN ("%ITMSPL_effect_timing%" == 4) BEGIN // Play sound (expiry sound)
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-									PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
-										PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
-													PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
-														PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
-															PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
-																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																END
-																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-																WRITE_LONG ("%fx_off%" + 0x2C) 998 // mark it for later detection
-															END
-														END
-													END
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					321 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN // Remove effects by resource
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-										PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
-												DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-													"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-												END
-												WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					318 324 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_MATCH "%ITMSPL_effect_parameter2%" WITH
-								15 19 BEGIN // RACE=ELF RACE=HALF_ELF
-									SET "racial_sleep_immunity" += 1
-									PATCH_IF ("racial_sleep_immunity" == 2) BEGIN
-										TEXT_SPRINT "sleep_type" "Sleep"
-									END
-								END
-								47 55 BEGIN // RACE=GOLEM|GENERAL=UNDEAD|RACE=MYCONID GENERAL=UNDEAD|RACE=GOLEM
-									TEXT_SPRINT "sleep_type" "Nausea"
-								END
-								DEFAULT
-							END
-						END
-					END
-					235 BEGIN // Wing buffet - ignore savingthrow and savebonus, match duration or less (see f.i. Dragon Wing Buffet "SPIN695.SPL")
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-													DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-														"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-													END
-													WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-													TEXT_SPRINT "sleep_type" "Knockback"
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					177 BEGIN // Use EFF file (see "https://github.com/Gibberlings3/EE_Fixpack/pull/37" for further details)
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-										PATCH_IF ("%ITMSPL_effect_duration%" <= "%fx_match_attribute_7%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-													INNER_PATCH_FILE "%ITMSPL_effect_resource%.eff" BEGIN
-														PATCH_MATCH LONG_AT 0x10 WITH
-															235 BEGIN // Wing buffet
-																TEXT_SPRINT "sleep_type" "Knockback"
-																DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																	"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																END
-																WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-															END
-															DEFAULT
-																SET "non-cosmetic_effects" = 1
-														END
-													END
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					328 BEGIN // Set splstate
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							PATCH_IF ("%ITMSPL_effect_power%" == "%fx_match_attribute_2%") BEGIN
-								PATCH_IF ("%ITMSPL_effect_timing%" == "%fx_match_attribute_5%") BEGIN
-									PATCH_IF ("%ITMSPL_effect_resist_dispel%" == "%fx_match_attribute_6%") OR ("%ITMSPL_effect_resist_dispel%" == 0 AND "%fx_match_attribute_6%" == BIT1) OR ("%ITMSPL_effect_resist_dispel%" == BIT1 AND "%fx_match_attribute_6%" == 0) BEGIN // 'resist_dispel=0' and 'resist_dispel=2' are basically the same thing (unless I'm missing something ...)
-										PATCH_IF ("%ITMSPL_effect_duration%" == "%fx_match_attribute_7%") BEGIN
-											PATCH_IF ("%ITMSPL_effect_probability1%" == "%fx_match_attribute_8%") BEGIN
-												PATCH_IF ("%ITMSPL_effect_probability2%" == "%fx_match_attribute_9%") BEGIN
-													PATCH_IF ("%ITMSPL_effect_dicenumber%" == "%fx_match_attribute_11%") BEGIN
-														PATCH_IF ("%ITMSPL_effect_dicesize%" == "%fx_match_attribute_12%") BEGIN
-															PATCH_IF ("%ITMSPL_effect_savingthrow%" == "%fx_match_attribute_13%") BEGIN
-																PATCH_IF ("%ITMSPL_effect_savebonus%" == "%fx_match_attribute_14%") BEGIN
-																	PATCH_IF ("%ITMSPL_effect_special%" == 1) AND ("%ITMSPL_effect_parameter2%" == 0) BEGIN
-																		DEFINE_ASSOCIATIVE_ARRAY "fx_ancillary" BEGIN
-																			"%ITMSPL_effect_opcode%" , "%ITMSPL_effect_target%" , "%ITMSPL_effect_power%" , "%ITMSPL_effect_parameter1%" , "%ITMSPL_effect_parameter2%" , "%ITMSPL_effect_timing%" , "%ITMSPL_effect_resist_dispel%" , "%ITMSPL_effect_duration%" , "%ITMSPL_effect_probability1%" , "%ITMSPL_effect_probability2%" , "%ITMSPL_effect_resource%" , "%ITMSPL_effect_dicenumber%" , "%ITMSPL_effect_dicesize%" , "%ITMSPL_effect_savingthrow%" , "%ITMSPL_effect_savebonus%" , "%ITMSPL_effect_special%" , "#%fx_ind%" => ""
-																		END
-																		WRITE_SHORT "%fx_off%" 998 // mark it for later detection
-																		TEXT_SPRINT "sleep_type" "Hopelessness"
-																	END ELSE BEGIN
-																		SET "non-cosmetic_effects" = 1
-																	END
-																END
-															END
-														END
-													END
-												END
-											END
-										END
-									END
-								END
-							END
-						END
-					END
-					269 BEGIN // Shake screen (effect is usually self-targeted, so no need to match fields)
-						TEXT_SPRINT "sleep_type" "Knockdown_ground-based"
-					END
-					206 WHEN ("%ITMSPL_effect_resource%" STRING_EQUAL_CASE "%file_res%") BEGIN END
-					DEFAULT
-						PATCH_IF ("%ITMSPL_effect_target%" == "%fx_match_attribute_1%") BEGIN
-							SET "non-cosmetic_effects" = 1
-							//PATCH_PRINT "non-cosmetic_effects => %ITMSPL_effect_opcode%, resource => %ITMSPL_effect_resource%"
-						END
-				END
-			END
-			// Special cases
-			PATCH_MATCH "%file_res%" WITH
-				"sper12" BEGIN // Ixil's Spike +6 (Hit target is pinned for 3 rounds ...)
-					TEXT_SPRINT "sleep_type" "Knockdown_ground-based" // treat it as a sui generis earthquake
-				END
-				DEFAULT
-			END
-			// If there are non-cosmetic effects, patch accordingly
-			PATCH_IF ("%non-cosmetic_effects%") OR !("%is_op39_on_all_abilities%") BEGIN
-				//PATCH_PRINT "%file_res%.%file_ext% needs subspell ..."
-				PATCH_IF ("%non-cosmetic_effects%") BEGIN
-					PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
-						//PATCH_PRINT "Restoring ancillary effect #%fx_ancillary_attribute_0% ..."
-						PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
-							7 8 9 41 50 51 52 61 141 174 215 321 BEGIN // if there are non-cosmetic effects, then keep the cosmetic ones (plus op321) on the parent file ...
-								LPF "ALTER_EFFECT" INT_VAR "check_globals" = 0 "silent" = 1 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 "opcode" = "%fx_ancillary_attribute_0%" END
-							END
-							DEFAULT
-								// op139, op142, ...
-								LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "multi_match" = 1 END
-						END
-					END
-				END ELSE BEGIN
-					LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END
-				END
-				// Generate a filename for the child "*.spl" file
-				LPF "OPCODE39_OVERHAUL#GET_UNIQUE_FILE_NAME" RET "filename" END
-				// Keep track of some parent file data
-				PATCH_MATCH "%file_ext%" WITH
-					"SPL" BEGIN
-						SET "parent_spell_type" = SHORT_AT 0x1C
-						SET "parent_primary_type" = BYTE_AT 0x25
-						SET "parent_secondary_type" = BYTE_AT 0x27
-						READ_ASCII 0x3A "parent_icon_c"
-						READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
-						SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
-					END
-					"ITM" BEGIN
-						SET "parent_spell_type" = 4 // Innate
-						READ_ASCII 0x3A "parent_icon_c"
-						READ_ASCII ("%ab_off%" + 0x4) "parent_icon_b"
-						SET "parent_ability_target" = BYTE_AT ("%ab_off%" + 0xC)
-						SET "parent_primary_type" = BYTE_AT ("%ab_off%" + 0x17)
-						SET "parent_secondary_type" = BYTE_AT ("%ab_off%" + 0x19)
-					END
-					DEFAULT
-				END
-				// Get current projectile type (so as to properly set the 'power' attribute)
-				LPF "OPCODE39_OVERHAUL#GET_PROJECTILE_TYPE" RET "projectile_type" END
-				// Create subspell
-				INNER_ACTION BEGIN
-					WITH_SCOPE BEGIN
-						CREATE "SPL" "%filename%"
-						COPY_EXISTING "%filename%.spl" "override"
-							/* Header */
-							WRITE_LONG NAME1 "-1"
-							WRITE_LONG NAME2 "-1"
-							WRITE_SHORT 0x1C "%parent_spell_type%"
-							WRITE_BYTE 0x25 "%parent_primary_type%"
-							WRITE_BYTE 0x27 "%parent_secondary_type%"
-							WRITE_LONG 0x34 1 // Spell level
-							WRITE_ASCII 0x3A "%parent_icon_c%"
-							WRITE_LONG UNIDENTIFIED_DESC "-1"
-							WRITE_LONG DESC "-1"
-							WRITE_LONG 0x64 0x72 // Extended Header offset
-							WRITE_SHORT 0x68 1 // Extended Header count
-							WRITE_LONG 0x6A 0x9A // Feature Block Table offset
-							INSERT_BYTES 0x72 0x28
-							/* Extended Header */
-							WRITE_BYTE 0x72 1 // Ability type
-							WRITE_SHORT 0x74 4 // Ability location: F13 (Special Ability)
-							WRITE_ASCII 0x76 ~%parent_icon_b%~ // Ability icon
-							WRITE_BYTE 0x7E "%parent_ability_target%" // Ability target
-							WRITE_SHORT 0x80 0x7FFF // Ability range
-							WRITE_SHORT 0x82 1 // Minimum level
-							WRITE_SHORT 0x98 IDS_OF_SYMBOL ("MISSILE" "None") // Projectile
-						BUT_ONLY
-					END
-				END
-				// 
-				LPF "ALTER_EFFECT" INT_VAR "silent" = 1 "check_globals" = 0 "header" = "%ab_ind%" "multi_match" = 1 "match_opcode" = 999 "opcode" = 146 "parameter1" = 0 "parameter2" = 1 "timing" = 1 "duration" = 0 "special" = 0 STR_VAR "resource" = "%filename%" END
-				INNER_ACTION BEGIN
-					COPY_EXISTING "%filename%.spl" "override"
-						/* Feature blocks */
-						PATCH_MATCH "%sleep_type%" WITH
-							"Sleep" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
-							END
-							"Unconsciousness" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
-							END
-							"Nausea" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
-							END
-							"Hopelessness" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								TEXT_SPRINT $"sleep_resref"("%DEST_RES%") ""
-							END
-							"Knockback" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
-							END
-							"Knockdown_ground-based" BEGIN
-								TEXT_SPRINT $"earthquake_resref"("%DEST_RES%") ""
-								//LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								PATCH_IF !("%game_is_iwdee%") BEGIN
-									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-									LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = 318 "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = 0 "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 STR_VAR "resource" = "%DEST_RES%" END
-							END
-							DEFAULT
-						END
-						// 
-						LPF "ADD_SPELL_EFFECT" INT_VAR "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_match_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
-						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
-							PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
-								7 8 9 41 50 51 52 61 141 215 WHEN ("%non-cosmetic_effects%") BEGIN END
-								174 WHEN !(("%non-cosmetic_effects%") AND ("%fx_ancillary_attribute_5%" == 4)) BEGIN END // skip non-expiry sound effects
-								DEFAULT
-									PATCH_MATCH "%fx_ancillary_attribute_0%" WITH
-										321 BEGIN
-											LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%DEST_RES%" END
-										END
-										DEFAULT
-											LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = ("%projectile_type%" == 3 ? 0 : "%fx_match_attribute_2%") "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = ("%fx_match_attribute_6%" == BIT0 ? BIT0 + BIT1 : "%fx_match_attribute_6%") "duration" = "%fx_ancillary_attribute_7%" "probability1" = 100 "probability2" = 0 "dicenumber" = 0 "dicesize" = 0 "savingthrow" = 0 "savebonus" = 0 "special" = ("%fx_ancillary_attribute_0%" == 174 ? 0 : "%fx_ancillary_attribute_15%") STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
-									END
-							END
-						END
-					BUT_ONLY_IF_IT_CHANGES
-				END
-			END ELSE BEGIN
-				// Just reorder effect stack
-				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 999 "multi_match" = 1 END // main effect
-				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 END // ancillary effects
-				// 
-				PATCH_MATCH "%file_ext%" WITH
-					"SPL" BEGIN
-						SET "opcode" = (SLONG_AT NAME1 > 0 ? 324 : 318)
-					END
-					"ITM" BEGIN
-						SET "opcode" = ((LONG_AT 0x18 BAND (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE"))) == (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE")) ? 324 : 318)
-					END
-					DEFAULT
-				END
-				PATCH_MATCH "%sleep_type%" WITH
-					"Sleep" BEGIN
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
-					END
-					"Unconsciousness" BEGIN
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
-					END
-					"Nausea" BEGIN
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "NAUSEA_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-					END
-					"Hopelessness" BEGIN
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "SLEEP_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-						TEXT_SPRINT $"sleep_resref"("%file_res%") ""
-					END
-					"Knockback" BEGIN
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKBACK_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-					END
-					"Knockdown_ground-based" BEGIN
-						TEXT_SPRINT $"earthquake_resref"("%file_res%") ""
-						PATCH_MATCH "%file_ext%" WITH
-							"SPL" BEGIN
-								//LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								PATCH_IF !("%game_is_iwdee%") BEGIN
-									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-									LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							"ITM" BEGIN
-								//LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("SPLSTATE" "KNOCKDOWN_GROUND-BASED_IMMUNITY") "parameter2" = 110 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("GENERAL" "WEAPON") "parameter2" = 103 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								PATCH_IF !("%game_is_iwdee%") BEGIN
-									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WYVERN") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "BEHOLDER") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-									LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "HARPY") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "IMP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MEPHIT") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DRAGON") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "DEMILICH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SHADOW") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRE") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WRAITH") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SPECTRAL_UNDEAD") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "WILL-O-WISP") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "SLIME") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("RACE" "MIST") "parameter2" = 104 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPIDER_WRAITH") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-								LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = IDS_OF_SYMBOL ("CLASS" "SPECTRAL_TROLL") "parameter2" = 105 "timing" = 0 "resist_dispel" = "%fx_match_attribute_6%" "duration" = 0 "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" STR_VAR "resource" = "%file_res%" END
-							END
-							DEFAULT
-						END
-					END
-					DEFAULT
-				END
-				PATCH_MATCH "%file_ext%" WITH
-					"SPL" BEGIN
-						LPF "ADD_SPELL_EFFECT" INT_VAR "header" = ("%ab_ind%" + 1) "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = "%fx_match_attribute_6%" "duration" = "%fx_match_attribute_7%" "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
-						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
-							LPF "ADD_SPELL_EFFECT" INT_VAR "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "header" = ("%ab_ind%" + 1) "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = "%fx_ancillary_attribute_2%" "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = "%fx_ancillary_attribute_6%" "duration" = "%fx_ancillary_attribute_7%" "probability1" = "%fx_ancillary_attribute_8%" "probability2" = "%fx_ancillary_attribute_9%" "dicenumber" = "%fx_ancillary_attribute_11%" "dicesize" = "%fx_ancillary_attribute_12%" "savingthrow" = "%fx_ancillary_attribute_13%" "savebonus" = "%fx_ancillary_attribute_14%" "special" = "%fx_ancillary_attribute_15%" STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
-						END
-					END
-					"ITM" BEGIN
-						LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "header" = ("%ab_ind%" + 1) "opcode" = "%fx_match_attribute_0%" "target" = "%fx_match_attribute_1%" "power" = "%fx_match_attribute_2%" "parameter1" = "%fx_match_attribute_3%" "parameter2" = "%fx_match_attribute_4%" "timing" = "%fx_match_attribute_5%" "resist_dispel" = "%fx_match_attribute_6%" "duration" = "%fx_match_attribute_7%" "probability1" = "%fx_match_attribute_8%" "probability2" = "%fx_match_attribute_9%" "dicenumber" = "%fx_match_attribute_11%" "dicesize" = "%fx_match_attribute_12%" "savingthrow" = "%fx_match_attribute_13%" "savebonus" = "%fx_match_attribute_14%" "special" = "%fx_match_attribute_15%" STR_VAR "resource" = "%fx_match_attribute_10%" END
-						PHP_EACH "fx_ancillary" AS "fx_ancillary_attribute" => "" BEGIN
-							LPF "ADD_ITEM_EFFECT" INT_VAR "type" = 99 "insert_point" = ("%fx_ancillary_attribute_0%" == 321 ? 0 : "-1") "header" = ("%ab_ind%" + 1) "opcode" = "%fx_ancillary_attribute_0%" "target" = "%fx_ancillary_attribute_1%" "power" = "%fx_ancillary_attribute_2%" "parameter1" = "%fx_ancillary_attribute_3%" "parameter2" = ("%fx_ancillary_attribute_0%" == 321 ? 2 : "%fx_ancillary_attribute_4%") "timing" = "%fx_ancillary_attribute_5%" "resist_dispel" = "%fx_ancillary_attribute_6%" "duration" = "%fx_ancillary_attribute_7%" "probability1" = "%fx_ancillary_attribute_8%" "probability2" = "%fx_ancillary_attribute_9%" "dicenumber" = "%fx_ancillary_attribute_11%" "dicesize" = "%fx_ancillary_attribute_12%" "savingthrow" = "%fx_ancillary_attribute_13%" "savebonus" = "%fx_ancillary_attribute_14%" "special" = "%fx_ancillary_attribute_15%" STR_VAR "resource" = "%fx_ancillary_attribute_10%" END
-						END
-					END
-					DEFAULT
-				END
-			END
-		END
-		// Clean up
-		PATCH_WITH_SCOPE BEGIN
-			PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
-				GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // NB.: same for "*.spl" and "*.itm"
-				PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
-					PATCH_MATCH SHORT_AT "%fx_off%" WITH
-						174 WHEN SLONG_AT ("%fx_off%" + 0x2C) == 998 BEGIN
-							WRITE_SHORT "%fx_off%" 998
-						END
-						DEFAULT
-					END
-				END
-				LPF "DELETE_EFFECT" INT_VAR "check_globals" = 0 "header" = "%ab_ind%" "match_opcode" = 998 "match_special" = 998 END
-			END
-		END
-	BUT_ONLY_IF_IT_CHANGES
-END
-
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Determine the projectile type (Single or AoE) of the current SPL/ITM ability
-///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-DEFINE_PATCH_FUNCTION "OPCODE39_OVERHAUL#GET_PROJECTILE_TYPE"
-RET
-	"projectile_type"
-BEGIN
-	SET "projectile_type" = 2 // Single target
-	PATCH_MATCH "%file_ext%" WITH
-		"SPL" BEGIN
-			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x26) - 1)
-		END
-		"ITM" BEGIN
-			LOOKUP_IDS_SYMBOL_OF_INT "projectile_res" "PROJECTL" (SHORT_AT ("%ab_off%" + 0x2A) - 1)
+		"spl" BEGIN
+			GET_OFFSET_ARRAY "ab_array" SPL_V10_HEADERS
 		END
 		DEFAULT
 	END
-	INNER_PATCH_FILE "%projectile_res%.pro" BEGIN
-		READ_SHORT 0x8 "projectile_type"
+	//
+	PHP_EACH "ab_array" AS "ab_ind" => "ab_off" BEGIN
+		GET_OFFSET_ARRAY2 "fx_array" "%ab_off%" SPL_V10_HEAD_EFFECTS // same for "*.spl" and "*.itm"
+		PHP_EACH "fx_array" AS "fx_ind" => "fx_off" BEGIN
+			PATCH_MATCH SHORT_AT "%fx_off%" WITH
+				39 BEGIN
+					WRITE_LONG ("%fx_off%" + 0x24) (THIS | BIT23) // https://github.com/Bubb13/EEex/pull/61
+				END
+				DEFAULT
+			END
+		END
 	END
 END
 
-DEFINE_PATCH_FUNCTION "OPCODE39_OVERHAUL#GET_UNIQUE_FILE_NAME"
-RET
-	"filename"
+DEFINE_PATCH_FUNCTION "GENERAL_RACE_CLASS_SPLSTATE_PERSONALSPACE_IMMUNITY"
 BEGIN
-	PATCH_IF (STRING_LENGTH "%file_res%" <= 7) BEGIN
-		SNPRINT "-1" "last_character" "%file_res%"
-		PATCH_MATCH "%last_character%" WITH
-			"[a-z]" BEGIN
-				SET "count" = 0
-				TEXT_SPRINT "suffix" $"digit"("%count%") // "0"
-				TEXT_SPRINT "filename" "%file_res%%suffix%"
-				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
-					SET "count" += 1
-					TEXT_SPRINT "suffix" $"digit"("%count%")
-					TEXT_SPRINT "filename" "%file_res%%suffix%"
-				END
-				PATCH_IF ("%count%" == 10) BEGIN
-					TO_UPPER "file_res"
-					TO_UPPER "file_ext"
-					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
-				END
+	PHP_EACH "patch_data" AS "key" => "value" BEGIN
+		PATCH_MATCH "%DEST_EXT%" WITH
+			"SPL" WHEN (SLONG_AT NAME1 > 0) BEGIN
+				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
 			END
-			"[0-9]" BEGIN
-				SET "count" = 0
-				TEXT_SPRINT "suffix" $"letter"("%count%") // "a"
-				TEXT_SPRINT "filename" "%file_res%%suffix%"
-				WHILE (FILE_EXISTS_IN_GAME "%filename%.spl") BEGIN
-					SET "count" += 1
-					TEXT_SPRINT "suffix" $"letter"("%count%")
-					TEXT_SPRINT "filename" "%file_res%%suffix%"
-				END
-				PATCH_IF ("%count%" == 26) BEGIN
-					TO_UPPER "file_res"
-					TO_UPPER "file_ext"
-					LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
-				END
+			"ITM" WHEN (LONG_AT 0x18 BAND (IDS_OF_SYMBOL ("ITEMFLAG" "DROPPABLE") BOR IDS_OF_SYMBOL ("ITEMFLAG" "DISPLAYABLE")) > 0) BEGIN
+				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 324 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
 			END
 			DEFAULT
-				TO_UPPER "file_res"
-				TO_UPPER "file_ext"
-				LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
+				LPF "CLONE_EFFECT" INT_VAR "match_opcode" = 39 "opcode" = 318 "parameter1" = ("%key_0%" STR_EQ "PERSONAL_SPACE" ? 0 : IDS_OF_SYMBOL ("%key_0%" "%key_1%")) "parameter2" = "%value%" "timing" = 0 "duration" = 0 "special" = 0 STR_VAR "resource" = "%DEST_RES%" END
 		END
-	END ELSE BEGIN
-		TO_UPPER "file_res"
-		TO_UPPER "file_ext"
-		LPF "GET_UNIQUE_FILE_NAME" STR_VAR "extension" = "spl" "base" = "CD_SleepType_%sleep_type%_Ability#%fx_match_attribute_16%_Effect#%fx_match_attribute_17%_%file_res%.%file_ext%" RET "filename" END
 	END
-	//
-	INNER_PATCH_SAVE "filename" "%filename%" BEGIN
-		REPLACE_TEXTUALLY EVALUATE_REGEXP "^__" "cd"
-	END
-	TO_LOWER "filename"
+END
+
+DEFINE_ACTION_FUNCTION "GET_BULKY_CREATURES"
+RET_ARRAY
+	"bulky_creature_list"
+BEGIN
+	COPY_EXISTING_REGEXP - "^.+\.cre$" "override"
+		PATCH_MATCH LONG_AT 0x28 WITH
+			IDS_OF_SYMBOL ("ANIMATE" "TANARRI")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_RED")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLACK")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_SILVER")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_GREEN")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_AQUA")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BLUE")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_BROWN")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_MULTICOLOR")
+			IDS_OF_SYMBOL ("ANIMATE" "DRAGON_PURPLE")
+			IDS_OF_SYMBOL ("ANIMATE" "DEMOGORGON")
+			IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_EARTH")
+			IDS_OF_SYMBOL ("ANIMATE" "SHAMBLING_MOUND")
+			IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE")
+			IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_FIRE_PURPLE")
+			IDS_OF_SYMBOL ("ANIMATE" "BURNING_MAN")
+			IDS_OF_SYMBOL ("ANIMATE" "ELEMENTAL_AIR")
+			IDS_OF_SYMBOL ("ANIMATE" "RAVER")
+			IDS_OF_SYMBOL ("ANIMATE" "SLAYER")
+			IDS_OF_SYMBOL ("ANIMATE" "SOLAR")
+			IDS_OF_SYMBOL ("ANIMATE" "DEVA_MONADIC")
+			IDS_OF_SYMBOL ("ANIMATE" "MELISSAN")
+			IDS_OF_SYMBOL ("ANIMATE" "GIANT_FIRE")
+			IDS_OF_SYMBOL ("ANIMATE" "GIANT_YAGA-SHURA")
+			IDS_OF_SYMBOL ("ANIMATE" "GOLEM_ICE")
+				BEGIN
+					TEXT_SPRINT $"bulky_creature_list"("%DEST_RES%") ""
+				END
+			DEFAULT
+		END
+	BUT_ONLY
 END


### PR DESCRIPTION
See [here](https://www.gibberlings3.net/forums/topic/35902-opcode-39-issues/) for further details.

Basically:
- Trolls are no longer immune to Sleep
  - I suspect they are immune to Sleep because they used to rely on scripts for their special revive mechanics.
    - However, since this is no longer the case, I do not see why they should be immune to it...
- Spells such as Chaotic Commands no longer protect against Earthquake and Nausea. In particular:
  - magically levitating creatures, flying creatures, oozes, incorporeal creatures are now immune to Earthquake-like attacks
  - the various creatures that are immune to `op39` are immune to both Sleep and Nausea attacks
    - This also implies that creatures such as Dragons get Nausea immunity, which in theory would be incorrect
      - However, as stated in the thread above, a more fine-grained solution would probably be too much for a fixpack...
- Spells that remove `op2` (Cure Sleep) now remove only true Sleep attacks
  - So for instance, Exaltation (`ohtyr1.spl`) cannot remove neither Earthquake nor Stinking Cloud. It can only remove Sleep, Emotion: Hopelessness, Color Spray and the like...
- As far as Knockback is concerned (see f.i. `spin695.spl` - Wing Buffet), creatures whose animation is hardcoded to be immune to [op235](https://gibberlings3.github.io/iesdp/opcodes/bgee.htm#op235) are now immune to the short-duration `op39` effect that accompanies `op235`
  - All other creatures are vulnerable to it (this is hopefully not a problem since this short-duration `op39` is only meant to temporary disable the targeted creatures during the buffet...)

This PR also provides the following fixes:
- **Earthquake**
  - Make sure all effects bypass Magic Resistance (since the spell is supposed to alter the environment instead of directly affecting the targeted creatures)
    - As of now, the damage opcode (`op12`) bypasses MR, whereas the Sleep opcode (`op39`) does not. I opted for `resist_dispel=0` for the aforementioned reason...
  - [iwdee] Creatures with 10 or more Hit Dice should be immune to this spell (as per spell description)
- [bgee] ****Stinking Cloud****
  - op324's `resource` field should not be empty
- [bgee] **bdsleep.spl**
  - Make sure all effects bypass Magic Resistance / are dispellable (so as to match `op39`, which bypasses MR and it's dispellable)