### PR TITLE
Fixed broken alignment target and saving throw penalty effects for Unholy Blight

### DIFF
--- a/eefixpack/files/tph/dw/holy_unholy.tph
+++ b/eefixpack/files/tph/dw/holy_unholy.tph
@@ -33,11 +33,13 @@ DEFINE_ACTION_FUNCTION holy_unholy BEGIN
     COPY_EXISTING "SPPR314.spl" override
       LPF DELETE_EFFECT END
       // level-independent effects
-      splprot_param="%SOURCE_RES%" STR_EQ sppr313 ? 38 : 36
+      splprot_param="%SOURCE_RES%" STR_EQ sppr314 ? 37 : 36
+      LPF ADD_SPELL_EFFECT INT_VAR opcode=324 target=2 parameter2=splprot_param STR_VAR resource="%SOURCE_RES%" END // block evil
+      splprot_param="%SOURCE_RES%" STR_EQ sppr314 ? 34 : 36
       LPF ADD_SPELL_EFFECT INT_VAR opcode=324 target=2 parameter2=splprot_param STR_VAR resource="%SOURCE_RES%" END // block non-evil/non-good
       LPF ADD_SPELL_EFFECT INT_VAR opcode=141 resist_dispel = 1 target=2 parameter2=26 END // lighting effect
       LPF ADD_SPELL_EFFECT INT_VAR opcode=174 resist_dispel = 1 target=2 timing=1 STR_VAR resource=EFF_P85 END // sound
-      LPF ADD_SPELL_EFFECT INT_VAR opcode=325 resist_dispel = 1 target=2 duration=24 parameter1="-2" parameter2=2 savingthrow=BIT0 END // save penalty
+      LPF ADD_SPELL_EFFECT INT_VAR opcode=325 resist_dispel = 1 target=2 duration=24 parameter1="-2" parameter2=0 savingthrow=BIT0 END // save penalty
       LPF ADD_SPELL_EFFECT INT_VAR opcode=54 resist_dispel = 1 target=2 parameter1="-2" duration=24 savingthrow=BIT0 END // THAC0 penalty
       LPF ADD_SPELL_EFFECT INT_VAR opcode=142 resist_dispel = 1 target=2 duration=24 parameter2=unholy savingthrow=BIT0 END // 'unholy blight' icon
       // level-dependent blocks


### PR DESCRIPTION
Hello,

The problems were two-fold:

1.) Unholy Blight was only affecting NEUTRAL aligned characters. Good and Evil aligned were immune.
2.) The saving throw penalty was implemented as a mod% operation, rather than an increment. This generally resulted in giving the targets a saving throw bonus of -10 across the board instead of a penalty of +2.

In addition, the operation for Creature type: ALIGNMENT bit_eq MASK_GOOD [0x1] (36) appears to be broken in BGEE. I don't know if this is a hard-coded bug or what, but it causes the spell to affect Evil aligned as well as Good. I solved this issue by creating two different Immunity to resource and message (324) entries, for Evil and Neutral. Holy Smite does not have any issues.