### PR TITLE
[bg2] Shadow Temple doors should not automatically open before the Shade Lord is dead

### DIFF
--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -167,7 +167,7 @@ COPY_EXISTING ~ar1100.bcs~ ~override~
 // open all shadow doors if shade lord is defeated
 COPY_EXISTING ~ar1401.bcs~ ~override~
   DECOMPILE_AND_PATCH BEGIN
-    REPLACE_TEXTUALLY ~\(TriggerActivation("Tran1404",TRUE)\)~ ~\1 OpenDoor("ShadowDoor01") OpenDoor("ShadowDoor02") OpenDoor("ShadowDoor03")~
+    REPLACE_TEXTUALLY ~\(TriggerActivation("Tran1404",FALSE)\)~ ~\1 OpenDoor("ShadowDoor01") OpenDoor("ShadowDoor02") OpenDoor("ShadowDoor03")~
   END
   BUT_ONLY
 


### PR DESCRIPTION
Fixes an issue in f044f2e which used the wrong condition to add the code for opening the shadow doors.