### PR TITLE
Remove strref for attack rolls from the gtu section

### DIFF
--- a/eefixpack/languages/en_us/gtu_bg2ee.tph
+++ b/eefixpack/languages/en_us/gtu_bg2ee.tph
@@ -875,7 +875,6 @@ WITH_TRA ~eefixpack/languages/en_us/gtu_bg2ee.tra~ BEGIN STRING_SET
   14492 @14492
   14607 @14607
   14631 @14631
-  14643 @14643
   14657 @14657
   14681 @14681
   14684 @14684

--- a/eefixpack/languages/en_us/gtu_bg2ee.tra
+++ b/eefixpack/languages/en_us/gtu_bg2ee.tra
@@ -4695,9 +4695,6 @@ When this spell is cast, it causes a ray of sunlight to beam down upon the caste
 @14631 = ~Different, yes, but not undesirable. There are those that fear change and change alone, whether they comprehend what might result or not.~
 
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
-@14643 = ~Attack Roll~
-
-// [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
 @14657 = ~Well... we have been told that one of the animal trainers darted out after the show began, but we have not been able to find him yet.~
 
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1

--- a/eefixpack/languages/en_us/gtu_bgee.tph
+++ b/eefixpack/languages/en_us/gtu_bgee.tph
@@ -805,7 +805,6 @@ WITH_TRA ~eefixpack/languages/en_us/gtu_bgee.tra~ BEGIN STRING_SET
   14511 @14511
   14543 @14543
   14571 @14571
-  14643 @14643
   14905 @14905
   15083 @15083
   15122 @15122

--- a/eefixpack/languages/en_us/gtu_bgee.tra
+++ b/eefixpack/languages/en_us/gtu_bgee.tra
@@ -4314,9 +4314,6 @@ Peace returned to the city, and Waterdhavians to their labors. To inhibit discov
 @14571 = ~'Twould be good if you tithed a few coins now and then. The favor of gods is worth a few gold.~ [YESLK28]
 
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
-@14643 = ~Attack Roll~
-
-// [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
 @14905 = ~Candlekeep~
 
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1

--- a/eefixpack/languages/en_us/gtu_iwdee.tph
+++ b/eefixpack/languages/en_us/gtu_iwdee.tph
@@ -210,7 +210,6 @@ WITH_TRA ~eefixpack/languages/en_us/gtu_iwdee.tra~ BEGIN STRING_SET
   14259 @14259
   14331 @14331
   14340 @14340
-  14643 @14643
   14695 @14695
   14698 @14698
   14700 @14700

--- a/eefixpack/languages/en_us/gtu_iwdee.tra
+++ b/eefixpack/languages/en_us/gtu_iwdee.tra
@@ -2013,9 +2013,6 @@ Type: One-handed
 Weight: 0~
 
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
-@14643 = ~Attack Roll~
-
-// [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
 @14695 = ~Potions are typically found in ceramic, crystal, glass, or metal flasks or vials. Flasks or other containers generally contain enough fluid to provide one person with one complete dose to achieve the effects of the potion.
 
 STATISTICS:

--- a/eefixpack/languages/en_us/gtu_pstee.tph
+++ b/eefixpack/languages/en_us/gtu_pstee.tph
@@ -1522,7 +1522,6 @@ WITH_TRA ~eefixpack/languages/en_us/gtu_pstee.tra~ BEGIN STRING_SET
   68402 @68402
   68452 @68452
   68456 @68456
-  68592 @68592
   68620 @68620
   68748 @68748
   68767 @68767

--- a/eefixpack/languages/en_us/gtu_pstee.tra
+++ b/eefixpack/languages/en_us/gtu_pstee.tra
@@ -7793,9 +7793,6 @@ Usable only by Godsmen
 // [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
 @68456 = ~"Then you shall die as well. Prepare yourself, spirit. We shall see if my mortality can be slain."~
 
-// [automatic scan] Issues: 1  | Surplus trailing whitespace at line 1
-@68592 = ~Attack Roll~
-
 // [automatic scan] Issues: 2  | Surplus leading whitespace at line 1 | Surplus trailing whitespace at line 1
 @68620 = ~ Find Trap Mode~
 


### PR DESCRIPTION
The engine expects a trailing space in this hardcoded string.