### PR TITLE
Fixed peridan, albruin, jansen gear getting their globals removed

### DIFF
--- a/eefixpack/files/tph/tbd_bg2ee_146.tph
+++ b/eefixpack/files/tph/tbd_bg2ee_146.tph
@@ -1,23 +1,23 @@
 COPY_EXISTING ~chan20.itm~ ~override~ // White Dragon Scale: shouldn't require creature target for AoE spell
   LPF ALTER_HEADER INT_VAR target = 4 range = 12 STR_VAR match_icon = spwi503b END // cone of cold
   BUT_ONLY
-  
+
 COPY_EXISTING ~comps65.itm~ ~override~ // purifier +5 (1pp cosmetic copy): : shouldn't require creature target for AoE spell
               ~sw1h65.itm~  ~override~ // purifier +5
   LPF ALTER_HEADER INT_VAR target = 4 STR_VAR match_icon = sppr303b END // dispel magic
   LPF ALTER_EFFECT INT_VAR opcode = 148 target = 1 STR_VAR match_resource = sppr303 END // actual cast
   BUT_ONLY
-  
+
 COPY_EXISTING ~globpur4.itm~  ~override~ // purple globe (wk) - mass cure is self-cast, shouldn't be able to pick a target
   LPF ALTER_HEADER INT_VAR target = 5 range = 1 STR_VAR match_icon = iglbpur1 END // dispel magic
   LPF ALTER_EFFECT INT_VAR target = 1 STR_VAR match_resource = sppr514 END // actual cast
   BUT_ONLY
-  
+
 COPY_EXISTING ~helm16.itm~ ~override~ // helm of brilliance: shouldn't require creature target for AoE spell
   LPF ALTER_HEADER INT_VAR target = 4 range = 15 STR_VAR match_icon = spwi714b END // prismatic spray header
   LPF ALTER_EFFECT INT_VAR opcode = 148 target = 1 STR_VAR match_resource = spwi714 END // actual cast
   BUT_ONLY
-  
+
 COPY_EXISTING ~helm17.itm~ ~override~ // skull of death: shouldn't require creature target for AoE spell
   LPF ALTER_HEADER INT_VAR target = 4 STR_VAR match_icon = spwi605b END // death spell header
   LPF ALTER_EFFECT INT_VAR opcode = 148 target = 1 STR_VAR match_resource = spwi605 END // actual cast
@@ -28,22 +28,22 @@ COPY_EXISTING ~ohdwand1.itm~ ~override~ // Wand of Glitterdust - cures invisibil
   LPF DELETE_EFFECT END // delete existing effects
   LPF ALTER_HEADER INT_VAR range = 30 primary = 0 secondary = 0 projectile = 1 END
   LPF ADD_ITEM_EFFECT INT_VAR opcode = 148 target = 1 parameter1 = 10 timing = 1 STR_VAR resource = spwi224 END
-  
+
 COPY_EXISTING ~restore.itm~ ~override~ // restoration scroll
   LPF ALTER_HEADER INT_VAR range = 1 STR_VAR match_icon = sppr417a END // restoration: range is touch
   BUT_ONLY
-  
+
 COPY_EXISTING ~comps34.itm~ ~override~ // albruin (1pp dupe)
               ~npmisc1.itm~ ~override~ // Jansen Spectroscopes
               ~sw1h32.itm~  ~override~ // peridan
               ~sw1h34.itm~  ~override~ // albruin
   LPF ALTER_HEADER INT_VAR range = 1 target = 5 primary = 0 secondary = 0 projectile = 1 STR_VAR match_icon = spwi203b END // just cast detect invisiblity directly
-  LPF DELETE_EFFECT INT_VAR header_type = 3 END // delete everything on the magical header
+  LPF DELETE_EFFECT INT_VAR check_globals = 0 header_type = 3 END // delete everything on the magical header (not the globals!)
   LPF ADD_ITEM_EFFECT INT_VAR opcode = 146 target = 2 parameter1 = 10 parameter2 = 2 timing = 1 STR_VAR resource = spwi203 END // and replace with a single cast
   BUT_ONLY
-  
+
 // IH from ring of gaxx can't be dispelled
 COPY_EXISTING ~ring39.itm~ ~override~
   LPF ALTER_EFFECT INT_VAR check_globals = 0 header_type = 3 match_resist_dispel = 2 resist_dispel = 3 END // delete everything on the magical headers
-  
-  
+
+


### PR DESCRIPTION
It was caused because DELETE_EFFECT requires check_globals = 0, otherwise "header_type = 3" will remove both the globals and the magical headers.