### PR TITLE
[iwd] Fix behavior of shriekers in Lower Dorn's Deep

### DIFF
--- a/eefixpack/files/baf/iwd/ar8005_bottom.baf
+++ b/eefixpack/files/baf/iwd/ar8005_bottom.baf
@@ -1,0 +1,68 @@
+IF
+  Global("8005_SPAWN","GLOBAL",1)
+  Global("SHRIEKER_SPAWN_TIMER","MYAREA",0)
+THEN
+  RESPONSE #100
+    SetGlobalTimer("SHRIEKER_SPAWN_TIMER","MYAREA",2400)
+    Continue()
+END
+
+IF
+  Global("8005_SPAWN","GLOBAL",1)
+  GlobalTimerExpired("SHRIEKER_SPAWN_TIMER","MYAREA")
+THEN
+  RESPONSE #100
+    SetGlobalTimer("SHRIEKER_SPAWN_TIMER","MYAREA",2400)
+    SetGlobal("8005_SPAWN_MYCO","GLOBAL",1)
+    Continue()
+END
+
+IF
+  !Global("8005_SPAWN_MYCO","GLOBAL",0)
+THEN
+  RESPONSE #100
+    SetGlobal("8005_SPAWN_MYCO","GLOBAL",0)
+    Continue()
+END
+
+IF
+  Global("8005_SUMMON","GLOBAL",1)
+  Global("8005_LAST_SUMMON","GLOBAL",0)
+THEN
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",1)
+    SetGlobal("8005_SUMMON_2","GLOBAL",1)
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",2)
+    SetGlobal("8005_SUMMON_3","GLOBAL",1)
+END
+
+IF
+  Global("8005_SUMMON","GLOBAL",1)
+  Global("8005_LAST_SUMMON","GLOBAL",1)
+THEN
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",0)
+    SetGlobal("8005_SUMMON_1","GLOBAL",1)
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",2)
+    SetGlobal("8005_SUMMON_3","GLOBAL",1)
+END
+
+IF
+  Global("8005_SUMMON","GLOBAL",1)
+  Global("8005_LAST_SUMMON","GLOBAL",2)
+THEN
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",0)
+    SetGlobal("8005_SUMMON_1","GLOBAL",1)
+  RESPONSE #100
+    SetGlobal("8005_SUMMON","GLOBAL",0)
+    SetGlobal("8005_LAST_SUMMON","GLOBAL",1)
+    SetGlobal("8005_SUMMON_2","GLOBAL",1)
+END

--- a/eefixpack/files/tph/a7/iwd_ldd_shriekers.tph
+++ b/eefixpack/files/tph/a7/iwd_ldd_shriekers.tph
@@ -1,0 +1,14 @@
+// Restores shriekers in Lower Dorn's Deep main building summoning help when detecting intruders
+
+// Because of an engine bug only a single defined ini spawn event works properly
+COPY_EXISTING ~ar8005.ini~ ~override~
+  // completely removing [8_HOURS] event
+  REPLACE_TEXTUALLY ~^\(events=.*\),8_HOURS~ ~\1~
+  REPLACE_TEXTUALLY ~^\[8_HOURS\].*[%WNL%]+[^%WNL%]+[%WNL%]+[^%WNL%]+[%WNL%]+~ ~~
+  // adding spawn definitions of the deleted event to the remaining event
+  REPLACE_TEXTUALLY ~^\(critters=.*,Salamander\)~ ~\1,MYCO1,MYCO2,MYCO3,MYCO4~
+  // updating trigger variables of myconid spawns: needed for manual control through the area script
+  REPLACE_TEXTUALLY ~\b8005_SPAWN\b~ ~8005_SPAWN_MYCO~
+BUT_ONLY
+
+EXTEND_BOTTOM ~ar8005.bcs~ ~eefixpack/files/baf/iwd/ar8005_bottom.baf~

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -234,6 +234,7 @@ COMPILE ~eefixpack/files/d/%game%_core_fixes.d~ // misc dialogue fixes
 
 INCLUDE ~eefixpack/files/tph/tbd_iwd_locals_scripts.tph~ // tbd, cam - region/container scripts can't use LOCALS-scoped variables
 INCLUDE ~eefixpack/files/tph/a7/iwd_luremaster.tph~ // luremaster cutscene fixes
+INCLUDE ~eefixpack/files/tph/a7/iwd_ldd_shriekers.tph~ // fixes shrieker behavior in Lower Dorn's Deep
 
 // tbd, cam
 // player ai checks if magical weapon present before casting shillelagh, but checks old resources


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/39414-iwdee-shouldnt-shriekers-in-lower-dorns-deep-do-something

Because of an INI-related engine bug the second event definition has to be merged with the first event to work properly. The different spawn delays are controlled through the area script.