### PR TITLE
[iwd] Level-lock spells invoked by items

### DIFF
--- a/eefixpack/files/tph/a7/item_spell_functions.tph
+++ b/eefixpack/files/tph/a7/item_spell_functions.tph
@@ -1,0 +1,199 @@
+// Calling this patch function on ITM resources ensures that effects of referenced spells are level-locked.
+// INT_VAR level        Minimum level of the extended SPL header that should be preserved.
+//                      Default: first available header
+// INT_VAR index        Optional index of a suffix to be added to the new resource name.
+//                      Index references a letter (-1: no suffix, 0->A, 1->B, 2->C, ...). Default: 0
+// INT_VAR silent       Specify non-zero to suppress warning messages.
+// INT_VAR forced       Specify non-zero to apply the patch regardless of SPL configuration.
+// STR_VAR itm_resref   Name of the current ITM resource. Default: %SOURCE_RES% if available, %spl_resref% otherwise
+// STR_VAR spl_resref   Name of the referenced SPL resource.
+// RET     new_resref   Updated SPL resource name after the patch operation.
+DEFINE_PATCH_FUNCTION a7_apply_fixed_spell_effect
+INT_VAR
+  level       = 0
+  index       = 0
+  silent      = 0
+  forced      = 0
+STR_VAR
+  itm_resref  = ~~
+  spl_resref  = ~~
+RET
+  new_resref
+BEGIN
+  SPRINT new_resref ~%spl_resref%~
+
+  PATCH_IF (~%itm_resref%~ STR_EQ ~~ && VARIABLE_IS_SET ~SOURCE_RES~) BEGIN
+    SPRINT itm_resref ~%SOURCE_RES%~
+  END ELSE BEGIN
+    SPRINT itm_resref ~%spl_resref%~
+  END
+
+  READ_ASCII 0 sig (8)
+  PATCH_IF (~%sig%~ STR_EQ ~ITM V1  ~) BEGIN
+    PATCH_IF (FILE_EXISTS_IN_GAME ~%spl_resref%.SPL~) BEGIN
+      // cloning spell (if needed)
+      INNER_ACTION BEGIN
+        OUTER_SET patch = forced
+        ACTION_IF (NOT patch) BEGIN
+          COPY_EXISTING ~%spl_resref%.SPL~ ~override~
+            READ_SHORT 0x68 num_spl_abils
+            SET patch = (num_spl_abils > 1)
+          BUT_ONLY IF_EXISTS
+        END
+
+        ACTION_IF (patch) BEGIN
+          LAF a7_derive_resref INT_VAR index silent STR_VAR resref = EVAL ~%itm_resref%~ ext = ~SPL~ RET new_resref END
+          COPY_EXISTING ~%spl_resref%.SPL~ ~override/%new_resref%.SPL~
+            LPF a7_lock_spell_level INT_VAR level spell_type = 4 silent END
+          BUT_ONLY
+        END
+      END
+
+      // updating spell references
+      PATCH_IF (NOT ~%new_resref%~ STR_EQ ~%spl_resref%~) BEGIN
+        READ_LONG 0x64 ofs_abils
+        READ_SHORT 0x68 num_abils
+        READ_LONG 0x6a ofs_effects
+        FOR (i = 0; i < num_abils; ++i) BEGIN
+          SET ofs_abil = ofs_abils + i * 56
+          READ_SHORT (ofs_abil + 0x1e) num_fx
+          READ_SHORT (ofs_abil + 0x20) idx_fx
+          FOR (j = 0; j < num_fx; ++j) BEGIN
+            SET ofs_fx = ofs_effects + (idx_fx + j) * 48
+            READ_SHORT ofs_fx opcode
+            PATCH_IF (opcode == 146 || opcode == 148) BEGIN
+              READ_LONG (ofs_fx + 0x08) mode
+              PATCH_IF (mode > 0) BEGIN
+                READ_ASCII (ofs_fx + 0x14) cur_spl_resref (8) NULL
+                PATCH_IF (~%cur_spl_resref%~ STR_EQ ~%spl_resref%~) BEGIN
+                  // updating SPL reference
+                  WRITE_ASCIIE (ofs_fx + 0x14) ~%new_resref%~ (8)
+                END
+              END
+            END
+          END
+        END
+      END
+    END
+  END ELSE BEGIN
+    PATCH_IF (NOT silent) BEGIN
+      PATCH_WARN ~WARNING: not an item resource~
+    END
+  END
+END
+
+// Converts the current SPL resource into a fixed single-level version.
+// INT_VAR level          Minimum level of the extended header that should be preserved.
+//                        Default: first available header
+// INT_VAR spell_type     The new spell type. Default: no change
+// INT_VAR name_strref    Strref of the new spell name. Default: no change
+// INT_VAR desc_strref    Strref of the new spell description. Default: no change
+// INT_VAR silent         Specify non-zero to suppress warning messages.
+DEFINE_PATCH_FUNCTION a7_lock_spell_level
+INT_VAR
+  level       = 0
+  spell_type  = "-1"
+  name_strref = "-2"
+  desc_strref = "-2"
+  silent      = 0
+BEGIN
+  READ_ASCII 0 sig (8)
+  PATCH_IF (~%sig%~ STR_EQ ~SPL V1  ~) BEGIN
+    PATCH_IF (spell_type >= 0 && spell_type <= 5) BEGIN
+      WRITE_SHORT 0x1c spell_type
+    END ELSE PATCH_IF (spell_type > 0) BEGIN
+      PATCH_IF (NOT silent) BEGIN
+        PATCH_WARN ~WARNING: invalid spell type specified: %spell_type%~
+      END
+    END
+
+    PATCH_IF (name_strref != "-2") BEGIN
+      WRITE_LONG NAME1 name_strref
+    END
+
+    PATCH_IF (desc_strref != "-2") BEGIN
+      WRITE_LONG UNIDENTIFIED_DESC desc_strref
+    END
+
+    // determining closest match
+    READ_LONG 0x64 ofs_abils
+    READ_SHORT 0x68 num_abils
+    SET matched_level = "-1"
+    SET matched_index = "-1"
+    FOR (i = 0; i < num_abils; ++i) BEGIN
+      SET cur_ofs = ofs_abils + i * 40
+      READ_SHORT (cur_ofs + 0x10) min_level
+      PATCH_IF ((level == 0 && matched_level < 0) || (min_level <= level && min_level > matched_level)) BEGIN
+        SET matched_level = min_level
+        SET matched_index = i
+      END
+    END
+
+    PATCH_IF (matched_index < 0 && NOT silent) BEGIN
+      PATCH_WARN ~WARNING: no matching minimum level found for level %level%~
+    END
+
+    // discarding mismatching structures
+    FOR (i = num_abils - 1; i >= 0; --i) BEGIN
+      SET cur_ofs = ofs_abils + i * 40
+      READ_SHORT (cur_ofs + 0x10) min_level
+      PATCH_IF (i != matched_index) BEGIN
+        LPF DELETE_SPELL_HEADER INT_VAR header_type = "-1" min_level END
+      END
+    END
+
+    // updating minimum level of the matching structure
+    READ_LONG 0x64 ofs_abils
+    READ_SHORT 0x68 num_abils
+    PATCH_IF (num_abils > 0) BEGIN
+      WRITE_SHORT (ofs_abils + 0x10) 1
+    END
+  END ELSE BEGIN
+    PATCH_IF (NOT silent) BEGIN
+      PATCH_WARN ~WARNING: not a spell resource~
+    END
+  END
+END
+
+// Returns a resource name that is derived from a given resource name.
+// INT_VAR index        An optional index of a suffix to be added to the resource name.
+//                      Index references a letter (-1: no suffix, 0->A, 1->B, 2->C, ...). Default: 0
+// INT_VAR silent       Specify non-zero to suppress warning messages.
+// STR_VAR resref       Base resource name to derive the new name from.
+// STR_VAR ext          File extension of the returned resource name. Used internally to check for existing files.
+// RET     new_resref   The new resource name.
+DEFINE_DIMORPHIC_FUNCTION a7_derive_resref
+INT_VAR
+  index   = 0
+  silent  = 0
+STR_VAR
+  resref  = ~~
+  ext     = ~~
+RET
+  new_resref
+BEGIN
+  OUTER_SPRINT new_resref ~%resref%~
+  ACTION_DEFINE_ARRAY letters BEGIN A B C D E F G H I J K L M N O P Q R S T U V W X Y Z END
+
+  ACTION_IF (index >= 0 && index < 26) BEGIN
+    OUTER_SPRINT suffix_letter $letters(~%index%~)
+    OUTER_SET max_len = 7
+  END ELSE BEGIN
+    OUTER_SPRINT suffix_letter ~~
+    OUTER_SET max_len = 8
+  END
+
+  ACTION_IF (STRING_LENGTH ~%new_resref%~ > max_len) BEGIN
+    LAF SUBSTRING INT_VAR start = 0 length = max_len STR_VAR string = EVAL ~%new_resref%~ RET new_resref = substring END
+  END
+
+  ACTION_IF (NOT ~%ext%~ STR_EQ ~~ && FILE_EXISTS_IN_GAME ~%new_resref%%suffix_letter%.%ext%~) BEGIN
+    LAF SUBSTRING INT_VAR start = 0 length = max_len STR_VAR string = EVAL ~#%new_resref%~ RET new_resref = substring END
+  END
+
+  OUTER_SPRINT new_resref ~%new_resref%%suffix_letter%~
+
+  ACTION_IF (NOT silent && NOT ~%ext%~ STR_EQ ~~ && FILE_EXISTS_IN_GAME ~%new_resref%.%ext%~) BEGIN
+    WARN ~WARNING: Resource already exists: %new_resref%.%ext%~
+  END
+END

--- a/eefixpack/files/tph/tbd_iwdee_146.tph
+++ b/eefixpack/files/tph/tbd_iwdee_146.tph
@@ -28,3 +28,124 @@ COPY_EXISTING ~scrlpet.itm~  ~override~ // stone to flesh scroll
               ~scrlpet2.itm~ ~override~ // stone to flesh scroll
   LPF ALTER_HEADER INT_VAR range = 40 STR_VAR match_icon = iscrl3p END // to match scstf
   BUT_ONLY
+
+// Several items cast spells that scale based on the caster level.
+// This patch clones these spells and locks them to the level that matches their item descriptions.
+// https://www.gibberlings3.net/forums/topic/39678-iwdee-list-of-items-which-should-cast-special-abilities-at-a-fixed-caster-level
+// https://www.gibberlings3.net/forums/topic/39677-iwdee-force-bullet-2-duration-of-otilukes-resilient-sphere-should-last-as-described
+// https://www.gibberlings3.net/forums/topic/39676-iwdee-mantle-of-hells-furnace-duration-of-charm-fire-elemental-kin-should-last-as-described
+
+INCLUDE ~eefixpack/files/tph/a7/item_spell_functions.tph~
+
+COPY_EXISTING ~AMUL15.ITM~ ~override~ // Shield Amulet
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPWI114~ END
+BUT_ONLY
+
+COPY_EXISTING ~AMULBAR.ITM~ ~override~  // Barrier Amulet
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 1 index = 0 STR_VAR spl_resref = ~SPWI408~ RET stoneskin_resref = new_resref END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 8 index = 1 STR_VAR spl_resref = ~SPWI406~ END
+BUT_ONLY
+
+COPY_EXISTING ~%stoneskin_resref%.SPL~ ~override~ // Stoneskin
+  // # skins: 1d4 + 2
+  LPF ALTER_EFFECT INT_VAR match_opcode = 218 parameter1 = 2 END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~BLRDECK.ITM~ ~override~  // Blur Deck
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 5 STR_VAR spl_resref = ~SPWI201~ END
+BUT_ONLY
+
+COPY_EXISTING ~BOOTMAN.ITM~ ~override~  // Boots of the Many Paths
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 4 STR_VAR spl_resref = ~SPWI201~ END
+BUT_ONLY
+
+COPY_EXISTING ~BRACEIP.ITM~ ~override~  // Bracers of Icelandic Pearl
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 11 index = 0 STR_VAR spl_resref = ~SPWI527~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 index = 1 STR_VAR spl_resref = ~SPWI503~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 17 index = 2 STR_VAR spl_resref = ~SPWI812~ END
+BUT_ONLY
+
+COPY_EXISTING ~FANGGF.ITM~ ~override~ // Fang of the Gloomfrost +4
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 13 STR_VAR spl_resref = ~SPWI610~ END
+BUT_ONLY
+
+COPY_EXISTING ~FORCE.ITM~ ~override~ // Force Bullet +2
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 0 forced = 1 STR_VAR spl_resref = ~SPWI413A~ RET otiluke_resref = new_resref END
+BUT_ONLY
+
+COPY_EXISTING ~%otiluke_resref%.SPL~ ~override~  // Otiluke's Resilient Sphere
+  // duration: 7 rounds
+  LPF ALTER_EFFECT INT_VAR match_timing = 0 duration = 42 END
+  LPF ALTER_EFFECT INT_VAR match_timing = 4 duration = 42 END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~JASPER.ITM~ ~override~ // Jasper's Ring of Shocking Grasp
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 2 STR_VAR spl_resref = ~SPWI115~ END
+BUT_ONLY
+
+COPY_EXISTING ~MANTLECS.ITM~ ~override~ // Mantle of the Coming Storm
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 1 STR_VAR spl_resref = ~SPPR403~ RET freeaction_resref = new_resref END
+BUT_ONLY
+
+COPY_EXISTING ~%freeaction_resref%.SPL~ ~override~  // Free Action
+  // duration: 4 turns
+  LPF ALTER_EFFECT INT_VAR match_timing = 0 duration = 240 END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~MANTLEHF.ITM~ ~override~ // Mantle of Hell's Furnace
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 3 index = 0 STR_VAR spl_resref = ~SPWI103~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 0 index = 1 forced = 1 STR_VAR spl_resref = ~SPITM99~ RET charm_elemental_resref = new_resref END
+BUT_ONLY
+
+COPY_EXISTING ~%charm_elemental_resref%.SPL~ ~override~  // Charm Fire Elemental Kin
+  // duration: 1 turn
+  LPF ALTER_EFFECT INT_VAR match_opcode = 5 duration = 60 END
+  LPF ALTER_EFFECT INT_VAR match_opcode = 142 duration = 60 END
+BUT_ONLY IF_EXISTS
+
+COPY_EXISTING ~MIRROR2.ITM~ ~override~  // Mirror of Black Ice Amulet
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 index = 0 STR_VAR spl_resref = ~SPWI201~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 index = 1 STR_VAR spl_resref = ~SPWI212~ END
+BUT_ONLY
+
+COPY_EXISTING ~ROGUE.ITM~ ~override~  // Rogue's Cowl
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPWI105~ END
+BUT_ONLY
+
+COPY_EXISTING ~SHAWM.ITM~ ~override~  // Owain's Lullabye
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPWI503~ END
+BUT_ONLY
+
+COPY_EXISTING ~SRING.ITM~ ~override~  // Ring of Sanctuary
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPPR109~ END
+BUT_ONLY
+
+COPY_EXISTING ~TIERNON.ITM~ ~override~  // Tiernon's Hearthstone
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 4 index = 0 STR_VAR spl_resref = ~SPPR216~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 1 index = 1 STR_VAR spl_resref = ~SPWI103~ END
+BUT_ONLY
+
+COPY_EXISTING ~TONGGF.ITM~ ~override~ // Tongue of the Gloomfrost +4
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPWI503~ END
+BUT_ONLY
+
+COPY_EXISTING ~U2HAM5A.ITM~ ~override~  // Demon's Breath +3
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 6 STR_VAR spl_resref = ~SPWI304~ END
+BUT_ONLY
+
+COPY_EXISTING ~ULRING.ITM~ ~override~ // Ulcaster Academy Ring
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 10 STR_VAR spl_resref = ~SPWI314~ END
+BUT_ONLY
+
+COPY_EXISTING ~VEXED3.ITM~ ~override~ // Vexed Armor
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 14 STR_VAR spl_resref = ~SPPR705~ END
+BUT_ONLY
+
+COPY_EXISTING ~VIOLIN.ITM~ ~override~ // Viol of the Hollow Men
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 9 STR_VAR spl_resref = ~SPWI426~ END
+BUT_ONLY
+
+COPY_EXISTING ~WANDARM.ITM~ ~override~  // Wand of Armory
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 3 index = 0 STR_VAR spl_resref = ~SPWI114~ END
+  LPF a7_apply_fixed_spell_effect INT_VAR level = 7 index = 1 STR_VAR spl_resref = ~SPWI317~ END
+BUT_ONLY


### PR DESCRIPTION
Several items cast spells that scale based on the caster level. This commit clones these spells and locks them to the level that matches their item descriptions.

https://www.gibberlings3.net/forums/topic/39678-iwdee-list-of-items-which-should-cast-special-abilities-at-a-fixed-caster-level

https://www.gibberlings3.net/forums/topic/39677-iwdee-force-bullet-2-duration-of-otilukes-resilient-sphere-should-last-as-described

https://www.gibberlings3.net/forums/topic/39676-iwdee-mantle-of-hells-furnace-duration-of-charm-fire-elemental-kin-should-last-as-described