### PR TITLE
[bg2ee] Fix access point of container in beholder lair (Eye quest)

### DIFF
--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -564,6 +564,11 @@ COPY_EXISTING ~ar3001.are~ ~override~
   END
   BUT_ONLY
 
+// Beholder Lair (Unseeing Eye quest) - access position of container should be accessible
+COPY_EXISTING ~ar0205.are~ ~override~
+  LPF ALTER_AREA_CONTAINER INT_VAR coord_y = 1170 STR_VAR container_name = ~Container 7~ END
+BUT_ONLY
+
 /////                                                  \\\\\
 ///// creature file fixes                              \\\\\
 /////                                                  \\\\\


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/39629-bg2ee-access-point-to-container-in-beholder-lair-unseeing-eye-quest-should-not-be-inaccessible