### PR TITLE
Fix for #curedef not removing the right deafness icon

### DIFF
--- a/eefixpack/files/tph/tbd_vfx_removal_bg.tph
+++ b/eefixpack/files/tph/tbd_vfx_removal_bg.tph
@@ -484,7 +484,7 @@ COPY_EXISTING ~bdbrd03.spl~  ~override~ // Dispel Confusion - cures confusion
 // create resource removal spell
 COPY ~eefixpack/files/spl/cdcure.spl~ ~override/#curedef.spl~
   LPF ADD_SPELL_EFFECT INT_VAR opcode =  81 target = 2 timing = 1                  END // cure: deafness
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 122 END // remove icon: deafness
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 112 END // remove icon: deafness
   PATCH_FOR_EACH res IN
 //    ~bdbrd04~  // (spl) Sound Burst - causes deafness - portrait icon 112
 //    ~bdshriek~ // (spl) Piercing Shriek - causes confusion deafness stun - [confusion routed to bdshriec.spl, stun to bdshries.spl, deaf to bdshried.spl]

--- a/eefixpack/files/tph/tbd_vfx_removal_bg2.tph
+++ b/eefixpack/files/tph/tbd_vfx_removal_bg2.tph
@@ -441,7 +441,7 @@ COPY_EXISTING ~bdbrd03.spl~  ~override~ // Dispel Confusion - cures confusion
 // create resource removal spell
 COPY ~eefixpack/files/spl/cdcure.spl~ ~override/#curedef.spl~
   LPF ADD_SPELL_EFFECT INT_VAR opcode =  81 target = 2 timing = 1                  END // cure: deafness
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 122 END // remove icon: deafness
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 112 END // remove icon: deafness
 /*
   PATCH_FOR_EACH res IN
               ~ohncoll.itm~  ~override~ // Collar Bell - cures sleep - causes deafness - portrait icon 112

--- a/eefixpack/files/tph/tbd_vfx_removal_iwd.tph
+++ b/eefixpack/files/tph/tbd_vfx_removal_iwd.tph
@@ -383,7 +383,7 @@ COPY_EXISTING ~bpdispel.spl~ ~override~ // <Invalid Strref -1> - cures berserk b
 // create resource removal spell
 COPY ~eefixpack/files/spl/cdcure.spl~ ~override/#curedef.spl~
   LPF ADD_SPELL_EFFECT INT_VAR opcode =  81 target = 2 timing = 1                  END // cure: deafness
-  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 122 END // remove icon: deafness
+  LPF ADD_SPELL_EFFECT INT_VAR opcode = 240 target = 2 timing = 1 parameter2 = 112 END // remove icon: deafness
 /*
   PATCH_FOR_EACH res IN
 //    ~dwfpgs01~ // (spl) <Invalid Strref -1> - causes deafness stun


### PR DESCRIPTION
Removes icon 122 (Minor Globe of invulnerability" instead of icon 112 (Deafness). 