### PR TITLE
Fix Chinese line breaks

### DIFF
--- a/eefixpack/languages/zh_cn/fixes_bg2ee.tra
+++ b/eefixpack/languages/zh_cn/fixes_bg2ee.tra
@@ -3,12 +3,12 @@
 // strings to replace, rename this file WITHOUT the underscore at the beginning. 
 
 //Fix UI mod bug caused by Chinese punctuation.
-@11293   = ~<CLASS>:等级<LEVEL>~
-@16480   = ~<CLASS>:等级<LEVEL>
+@11293   = ~<CLASS>: 等级<LEVEL>~
+@16480   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 下个等级: <NEXTLEVEL>~
-@19719   = ~<CLASS>:等级<LEVEL>
+@19719   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 暂不生效~
-@19720   = ~<CLASS>:等级<LEVEL>
+@19720   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>~

--- a/eefixpack/languages/zh_cn/fixes_bgee.tra
+++ b/eefixpack/languages/zh_cn/fixes_bgee.tra
@@ -3,12 +3,12 @@
 // strings to replace, rename this file WITHOUT the underscore at the beginning. 
 
 //Fix UI mod bug caused by Chinese punctuation.
-@11293   = ~<CLASS>:等级<LEVEL>~
-@16480   = ~<CLASS>:等级<LEVEL>
+@11293   = ~<CLASS>: 等级<LEVEL>~
+@16480   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 下个等级: <NEXTLEVEL>~
-@19719   = ~<CLASS>:等级<LEVEL>
+@19719   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 暂不生效~
-@19720   = ~<CLASS>:等级<LEVEL>
+@19720   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>~

--- a/eefixpack/languages/zh_cn/fixes_iwdee.tra
+++ b/eefixpack/languages/zh_cn/fixes_iwdee.tra
@@ -3,12 +3,12 @@
 // strings to replace, rename this file WITHOUT the underscore at the beginning. 
 
 //Fix UI mod bug caused by Chinese punctuation.
-@11293   = ~<CLASS>:等级<LEVEL>~
-@16480   = ~<CLASS>:等级<LEVEL>
+@11293   = ~<CLASS>: 等级<LEVEL>~
+@16480   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 下个等级: <NEXTLEVEL>~
-@19719   = ~<CLASS>:等级<LEVEL>
+@19719   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 暂不生效~
-@19720   = ~<CLASS>:等级<LEVEL>
+@19720   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>~

--- a/eefixpack/languages/zh_cn/fixes_pstee.tra
+++ b/eefixpack/languages/zh_cn/fixes_pstee.tra
@@ -3,12 +3,12 @@
 // strings to replace, rename this file WITHOUT the underscore at the beginning. 
 
 //Fix UI mod bug caused by Chinese punctuation.
-@69270   = ~<CLASS>:等级<LEVEL>~
-@69269   = ~<CLASS>:等级<LEVEL>
+@69270   = ~<CLASS>: 等级<LEVEL>~
+@69269   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 下个等级: <NEXTLEVEL>~
-@69390   = ~<CLASS>:等级<LEVEL>
+@69390   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>
 暂不生效~
-@69292   = ~<CLASS>:等级<LEVEL>
+@69292   = ~<CLASS>: 等级<LEVEL>
 经验值: <EXPERIENCE>~


### PR DESCRIPTION
Remove spaces retained for aesthetic purposes to prevent unexpected line breaks in Chinese text layout within the Infinite Engine.