### PR TITLE
Fix for globe of blades not adding an evasion check for its own resource

### DIFF
--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -1026,7 +1026,7 @@ COPY_EXISTING ~sppr720.spl~ ~override~ // earthquake: "creatures with 10 or more
 
 // evasion fixes - missing evasion check
 COPY_EXISTING ~sppr725d.spl~ ~override~ // aura o' flaming death
-  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 324 target = 2 parameter2 = 63 END 
+  LPF ADD_SPELL_EFFECT INT_VAR insert_point = 0 opcode = 324 target = 2 parameter2 = 63 STR_VAR resource = "sppr725d" END 
 
 COPY_EXISTING ~spra302.spl~ ~override~ // Minor Spell Deflection [ranger]
   LPF DELETE_EFFECT INT_VAR header = 6 multi_match = 1 match_opcode = 233 END // dupe 233s ar level 11


### PR DESCRIPTION
Evasion check had no resource to check against.