### PR TITLE
[bg, bg2, iwd] Fixing "null" damage display bug for 0d0+0 damage item…

### DIFF
--- a/eefixpack/files/tph/a7/ui_null_damage_display.tph
+++ b/eefixpack/files/tph/a7/ui_null_damage_display.tph
@@ -1,0 +1,26 @@
+// [bg, sod, bg2, iwd] Fixes "(null)" damage display bug on inventory screen for weapons that only deal damage through effects
+// https://www.gibberlings3.net/forums/topic/41055-display-issue-in-inventory-screen-with-weapons-that-dont-deal-physical-damage
+
+<<<<<<<< .../inlined/eefixpack/getInventoryDamageDetails
+function getInventoryDamageDetails()
+	local str = ""
+	if characters[id].damage.detailsOffhand == nil or characters[id].damage.detailsOffhand == "" then
+		str = characters[id].damage.details
+	else
+		str = characters[id].damage.details.."\n\n"..characters[id].damage.detailsOffhand
+	end
+	local dice = Infinity_FetchString(0xf00000 + 564)
+	str = string.gsub(str, "%(null%)", "0" .. dice .. "0")
+	return str
+end
+>>>>>>>>
+COPY_EXISTING ~ui.menu~ ~override~
+  SET pos1 = INDEX_BUFFER(~function[ %TAB%%WNL%]+getInventoryDamageDetails()~)
+  PATCH_IF (pos1 >= 0) BEGIN
+    SET pos2 = INDEX_BUFFER(~function ~ pos1 + 1)
+    PATCH_IF (pos2 > pos1) BEGIN
+      DELETE_BYTES pos1 (pos2 - pos1)
+      INSERT_FILE pos1 ~.../inlined/eefixpack/getInventoryDamageDetails~
+    END
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -15,6 +15,7 @@ INCLUDE ~eefixpack/files/tph/launcher_damage_types.tph~ // many bows/xbows lack 
 INCLUDE ~eefixpack/files/tph/debug_area_listings.tph~ // correcting area names/styles in console menu
 INCLUDE ~eefixpack/files/tph/a7/bg2_ui_logo_fix.tph~  // updating game logo when transitioning from SoA to ToB campaign
 INCLUDE ~eefixpack/files/tph/a7/ui_quit_menu.tph~     // allow to force-quit the game if cutscene mode is active
+INCLUDE ~eefixpack/files/tph/a7/ui_null_damage_display.tph~ // fixes "(null)" damage display bug on inventory screen
 
 /////                                                  \\\\\
 ///// ids/2da/ini/gam fixes                            \\\\\

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -20,6 +20,7 @@ INCLUDE ~eefixpack/files/tph/launcher_damage_types.tph~ // many bows/xbows lack 
 /////                                                  \\\\\
 
 INCLUDE ~eefixpack/files/tph/a7/ui_quit_menu.tph~     // allow to force-quit the game if cutscene mode is active
+INCLUDE ~eefixpack/files/tph/a7/ui_null_damage_display.tph~ // fixes "(null)" damage display bug on inventory screen
 
 ACTION_IF game_includes_sod BEGIN
   WITH_SCOPE BEGIN

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -14,6 +14,7 @@ INCLUDE ~eefixpack/files/tph/launcher_damage_types.tph~ // many bows/xbows lack 
 
 INCLUDE ~eefixpack/files/tph/debug_area_listings.tph~ // correcting area names/styles in console menu
 INCLUDE ~eefixpack/files/tph/a7/ui_quit_menu.tph~     // allow to force-quit the game if cutscene mode is active
+INCLUDE ~eefixpack/files/tph/a7/ui_null_damage_display.tph~ // fixes "(null)" damage display bug on inventory screen
 
 COPY_EXISTING ~ui.menu~ ~override~
   // fix scrollbar position of kit selection list in the character creation menu


### PR DESCRIPTION
…s (supplementary fix)

Supplement to 17f5c7b1a3c359eeb1ece00b0f65f3b7ea49b379 that handles the "null" damage display bug more generally

https://www.gibberlings3.net/forums/topic/41055-display-issue-in-inventory-screen-with-weapons-that-dont-deal-physical-damage