### PR TITLE
[All] Fix parameter order in script trigger definitions

### DIFF
--- a/eefixpack/files/tph/a7/trigger_param_fix.tph
+++ b/eefixpack/files/tph/a7/trigger_param_fix.tph
@@ -1,0 +1,8 @@
+// Fixes incorrect parameter order of NearSavedLocation() and CheckItemSlot() script triggers
+
+COPY_EXISTING ~trigger.ids~ ~override~
+  PATCH_FOR_EACH trigger IN ~NearSavedLocation~ ~CheckItemSlot~ BEGIN
+    REPLACE_TEXTUALLY ~\(0x[0-9a-f]+\)[ %TAB%]+%trigger%(\(O:[^,]+\),\(S:[^,]+\),\(I:[^)]+\))~
+                      ~\1 %trigger%(\3,\2,\4)~
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -23,6 +23,7 @@ INCLUDE ~eefixpack/files/tph/a7/ui_null_damage_display.tph~ // fixes "(null)" da
 
 INCLUDE ~eefixpack/files/tph/gam_npcs.tph~ // corrects spawn orientation for GAM NPCs
 INCLUDE ~eefixpack/files/tph/a7/action_changestoremarkup_fix.tph~ // fix parameter order in the ChangeStoreMarkup() script action
+INCLUDE ~eefixpack/files/tph/a7/trigger_param_fix.tph~ // fix parameter order in several script trigger definitions
 INCLUDE ~eefixpack/files/tph/a7/anim_3001.tph~ // fix missing creature animation definitions for Neothelid
 INCLUDE ~eefixpack/files/tph/a7/cre_anim_fixes.tph~ // fix height offsets of health bar positions for creature animations
 INCLUDE ~eefixpack/files/tph/animation_ini_fixes.tph~ // errors in animation definitions

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -64,6 +64,7 @@ END
 
 INCLUDE ~eefixpack/files/tph/gam_npcs.tph~ // corrects spawn orientation for GAM NPCs
 INCLUDE ~eefixpack/files/tph/a7/action_changestoremarkup_fix.tph~ // fix parameter order in the ChangeStoreMarkup() script action
+INCLUDE ~eefixpack/files/tph/a7/trigger_param_fix.tph~ // fix parameter order in several script trigger definitions
 INCLUDE ~eefixpack/files/tph/a7/anim_3001.tph~ // fix missing creature animation definitions for Neothelid
 INCLUDE ~eefixpack/files/tph/a7/cre_anim_fixes.tph~ // fix height offsets of health bar positions for creature animations
 INCLUDE ~eefixpack/files/tph/animation_ini_fixes.tph~ // errors in animation definitions

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -26,6 +26,7 @@ BUT_ONLY
 /////                                                  \\\\\
 
 INCLUDE ~eefixpack/files/tph/a7/action_changestoremarkup_fix.tph~ // fix parameter order in the ChangeStoreMarkup() script action
+INCLUDE ~eefixpack/files/tph/a7/trigger_param_fix.tph~ // fix parameter order in several script trigger definitions
 INCLUDE ~eefixpack/files/tph/a7/anim_3001.tph~ // fix missing creature animation definitions for Neothelid
 INCLUDE ~eefixpack/files/tph/a7/cre_anim_fixes.tph~ // fix height offsets of health bar positions for creature animations
 INCLUDE ~eefixpack/files/tph/a7/iwd_movescale_fixes.tph~ // fixes movement rate in several creature animation definitions

--- a/eefixpack/files/tph/pstee.tph
+++ b/eefixpack/files/tph/pstee.tph
@@ -47,6 +47,7 @@ COPY_EXISTING ~damages.ids~ ~override~
 APPEND ~splstate.ids~ ~136 DEATH_IMMUNITY~
 
 INCLUDE ~eefixpack/files/tph/a7/action_changestoremarkup_fix.tph~ // fix parameter order in the ChangeStoreMarkup() script action
+INCLUDE ~eefixpack/files/tph/a7/trigger_param_fix.tph~ // fix parameter order in several script trigger definitions
 INCLUDE ~eefixpack/files/tph/tbd_splprot_kitfix.tph~ // tbd, cam: fixing kit check to be a numerical equality check, not bitwise
 
 INCLUDE ~eefixpack/files/tph/clswpbon.tpa~ // tbd, cam: fix non-prof penalties for shadowdancers, mage-thieves


### PR DESCRIPTION
Script triggers NearSavedLocation() and CheckItemSlot() are defined with their object and string parameters in the wrong order.

This is not an issue for BCS scripts since WeiDU and NI compilers convert the triggers into correct byte code. The engine's own compiler, however, throws an error if it encounters these triggers in dialog trigger blocks.