### PR TITLE
[bg2] Expand chapter check in various creature spawning scripts

### DIFF
--- a/eefixpack/files/tph/a7/bg2_chapter6_scripts.tph
+++ b/eefixpack/files/tph/a7/bg2_chapter6_scripts.tph
@@ -1,0 +1,21 @@
+// Scripts for spawning creatures in chapter 6: Expand check to chapter > 5
+COPY_EXISTING ~c6behold.bcs~ ~override~
+              ~c6goljug.bcs~ ~override~
+              ~c6golsto.bcs~ ~override~
+              ~c6mindul.bcs~ ~override~
+              ~c6rakraj.bcs~ ~override~
+              ~c6vamp.bcs~   ~override~
+              ~c6vamver.bcs~ ~override~
+              ~c6weregr.bcs~ ~override~
+  DECOMPILE_AND_PATCH BEGIN
+    REPLACE_TEXTUALLY ~Global("Chapter","GLOBAL",6)~ ~GlobalGT("Chapter","GLOBAL",5)~
+  END
+BUT_ONLY
+
+// Beholders spawning in Athkatla's sewers should depend on the outcome of the Unseeing Eye quest.
+// Adding AreaCheck() since the script can theoretically be used globally in the game for spawning beholders.
+COPY_EXISTING ~c6behold.bcs~ ~override~
+  DECOMPILE_AND_PATCH BEGIN
+    REPLACE_TEXTUALLY ~\(Global\(GT\)?("Chapter","GLOBAL",.*\)~ ~\1 OR(2) !Global("UnseeingEye","GLOBAL",2) !AreaCheck("AR0701")~
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -202,6 +202,7 @@ INCLUDE ~eefixpack/files/tph/temple.tph~           // temple changes for ar0900/
 INCLUDE ~eefixpack/files/tph/hexxat_death.tph~     // better death scripting for hexxat
 INCLUDE ~eefixpack/files/tph/bdjoinxp.tph~         // fix random XP gains on NPC dual-classes and other events
 INCLUDE ~eefixpack/files/tph/ground_lightning.tph~ // certain projectiles from ground traps cause crashes
+INCLUDE ~eefixpack/files/tph/a7/bg2_chapter6_scripts.tph~ // improve chapter checks in creature spawning scripts
 
 // fix misspelled resref
 COPY_EXISTING ~cut85a.bcs~   ~override~


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/41221-bg2ee-beholders-spawn-in-athkatlas-sewers-in-chapter-6

Several scripts for spawning creatures check specifically for chapter 6. However, these scripts should also fire if the party advanced to Suldanessellar and reached chapter 7.

The beholder spawning script in Athkatla's sewers should also depend on the outcome of the Unseeing Eye quest.