### PR TITLE
[bg2] Trigger state of ground traps in BP2 Staging Area should not persist indefinitely

### DIFF
--- a/eefixpack/files/baf/bp2_noser_traps.baf
+++ b/eefixpack/files/baf/bp2_noser_traps.baf
@@ -1,0 +1,7 @@
+IF
+  Entered([ANYONE])
+  HasItemEquiped("OHBNOSHU",LastTrigger)
+THEN
+  RESPONSE #100
+    NoAction()
+END

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -559,6 +559,12 @@ ACTION_IF (NOT FILE_EXISTS_IN_GAME ~AR6300.BCS~) BEGIN
 END
 EXTEND_TOP ~AR6300.BCS~ ~eefixpack/files/baf/ar6300_unlock_ar5500.baf~
 
+// Trigger state of ground traps that require the Noser Uniform being equipped in the BP2 Staging Area (OH8100)
+// should not persist indefinitely after they are passed.
+ACTION_FOR_EACH resref IN ~ohbloun1~ ~ohbloun2~ ~ohbloun3~ ~ohbloun4~ BEGIN
+  EXTEND_BOTTOM ~%resref%.bcs~ ~eefixpack/files/baf/bp2_noser_traps.baf~
+END
+
 INCLUDE ~eefixpack/files/tph/ending_cutscenes.tph~ // tightening end of cutscenes
 
 /////                                                  \\\\\


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/39539-bg2ee-black-pits-2-traps-in-staging-area-should-not-trigger-unexpectedly

Several ground traps in the BG2 Staging Area (OH8100) require the Noser Uniform to be equipped to pass them safely. However, the state of the triggers is delayed indefinitely and will fire if the player takes the uniform off.

This fix "consumes" the firing state of the trigger, so that the uniform can be taken off at any time without setting all passed ground traps off at once.