### PR TITLE
Innate Domination string- and icon fix

### DIFF
--- a/eefixpack/files/tph/angel/innate_domination_fix.tph
+++ b/eefixpack/files/tph/angel/innate_domination_fix.tph
@@ -1,0 +1,31 @@
+// SPIN883	- VAMPIRE_DOMINATION
+// SPIN910	- PSIONIC_DOMINATION
+// SPIN975	- MIND_FLAYER_DOMINATION
+// SPIN985	- BEHOLDER_DOMINATION
+//
+// These all clearly are domination effects, but they display
+// the "charmed" string and -icon, not the "dominated" ones.
+//
+// The cleric- and wizard spells get it right, as do some others.
+
+COPY_EXISTING "spin883.spl" "override"
+              "spin910.spl" "override"
+              "spin975.spl" "override"
+              "spin985.spl" "override"
+  LAUNCH_PATCH_FUNCTION ALTER_EFFECT
+    INT_VAR
+    match_opcode	= 5
+    parameter2		= 1003
+  END
+
+  LAUNCH_PATCH_FUNCTION CLONE_EFFECT
+    INT_VAR
+    match_opcode	= 5
+    opcode		= 139
+    timing		= 1
+    duration		= 0
+    parameter1		= game_is_bgee ? 26206 : 8364
+    parameter2		= 0
+  END
+
+

--- a/eefixpack/files/tph/bg_bg2_common_spell_fixes.tph
+++ b/eefixpack/files/tph/bg_bg2_common_spell_fixes.tph
@@ -774,3 +774,13 @@ COPY_EXISTING ~spwi622.spl~ ~override~ // Conjure Earth Elemental [sod, bg2]
 // mismatching save types between cosmetics and actual effects
 COPY_EXISTING  ~spwm179.spl~  ~override~ // Polymorph Other (wild surge)
   LPF ALTER_EFFECT INT_VAR match_savingthrow = BIT4 savingthrow = BIT0 END 
+
+//angel
+// various innate domination effects display the charm icon and -string
+// instead of the domination ones
+
+WITH_SCOPE BEGIN
+  INCLUDE "eefixpack/files/tph/angel/innate_domination_fix.tph"
+END
+
+


### PR DESCRIPTION
Several innate domination spells, namely those of vampires, mind flayers and beholders, are using the charm portrait icon and -string instead of the domination ones.

The wizard- and cleric spells, and a few other innates like Demogorgon's already got it right.