### PR TITLE
[pst] Fix accessibility issues of bags

### DIFF
--- a/eefixpack/files/tph/a7/pst_ui_open_bags_fix.tph
+++ b/eefixpack/files/tph/a7/pst_ui_open_bags_fix.tph
@@ -1,0 +1,29 @@
+// Button for opening bags should not be available if the bag is in a static container (chest, ground pile, etc.), or for sale in a store
+ACTION_DEFINE_ASSOCIATIVE_ARRAY ui_item_fixes_lua BEGIN
+  // lua function name, search string => replacement string
+  ~itemDescLeftButtonEnabled()~, ~^[ %TAB%]+else[ %TAB%%WNL%]+return itemDesc.item.isBag~ => ~%TAB%elseif(itemDesc.mode == 1) then%WNL%%TAB%%TAB%return (itemDesc.item.isBag == 1 and itemDesc.storeItem == 0)~
+  ~itemDescLeftButtonText()~, ~^[ %TAB%]+else[ %TAB%%WNL%]+\(return t('OPEN_CONTAINER_BUTTON')\)~ => ~%TAB%elseif(itemDesc.mode == 1) then%WNL%%TAB%%TAB%\1~
+  ~itemDescLeftButtonAction()~, ~^^[ %TAB%]+else[ %TAB%%WNL%]+\(storeScreen:OpenBag(itemDesc.item.res)\)~ => ~%TAB%elseif(itemDesc.mode == 1) then%WNL%%TAB%%TAB%\1~
+END
+
+COPY_EXISTING ~ui.menu~ ~override~
+  PHP_EACH ui_item_fixes_lua AS header => replace BEGIN
+    SPRINT function $header(~0~)
+    SPRINT search $header(~1~)
+    SET pos1 = INDEX_BUFFER(~function[ %TAB%]+%function%~)
+    PATCH_IF (pos1 >= 0) BEGIN
+      SET pos2 = INDEX_BUFFER(~^end[%WNL%]+~ pos1)
+      PATCH_IF (pos2 > pos1) BEGIN
+        SET old_len = pos2 - pos1
+        READ_ASCII pos1 block (old_len)
+        INNER_PATCH_SAVE new_block ~%block%~ BEGIN
+          REPLACE_TEXTUALLY ~%search%~ ~%replace%~
+        END
+        SET new_len = STRING_LENGTH ~%new_block%~
+        DELETE_BYTES pos1 old_len
+        INSERT_BYTES pos1 new_len
+        WRITE_ASCIIE pos1 ~%new_block%~ (new_len)
+      END
+    END
+  END
+BUT_ONLY

--- a/eefixpack/files/tph/pstee.tph
+++ b/eefixpack/files/tph/pstee.tph
@@ -18,6 +18,8 @@ BUT_ONLY
 // Strength description text on the Statistics screen should work for all potential strength values
 INCLUDE ~eefixpack/files/tph/a7/pst_ui_fix_str_help.tph~
 
+INCLUDE ~eefixpack/files/tph/a7/pst_ui_open_bags_fix.tph~ // fixes bag accessibility issues
+
 INCLUDE ~eefixpack/files/tph/debug_area_listings.tph~ // correcting area names/styles in console menu
 
 /////                                                  \\\\\


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/41295-pstee-opening-a-bag-inside-a-container-crashes-the-game

Bags in chests, ground piles, or other static containers could be originally opened, which crashed the game. Bags for sale in stores could also be opened which caused subsequent purchases to be stored in the bag instead of the player's inventory.

This fix hides the "Open container" button in these situations.