### PR TITLE
Fix automap notes in thief's "Set Snare" abilities

### DIFF
--- a/eefixpack/files/tph/a7/snares_autonotes_fix.tph
+++ b/eefixpack/files/tph/a7/snares_autonotes_fix.tph
@@ -1,0 +1,69 @@
+// Fixes adding an automap note to the area when a snare is set
+// - Moves global effect "Set Automap Note" from snare resource to "set snare" resource as ability effect
+// - Fixes incorrect note string in IWDEE
+// - Adds a missing "Remove Automap Note" effect to special snare resource
+
+ACTION_DEFINE_ASSOCIATIVE_ARRAY set_snare_array BEGIN
+  // "set snare" resref => "snare" resref
+  ~SPCL412~ => ~SPCL411~  // Set Snare
+  ~SPCL414~ => ~SPCL415~  // Set Special Snare
+  ~SPCL910~ => ~SPCL910B~ // Set Spike Trap
+  ~SPCL911~ => ~SPCL911B~ // Set Exploding Trap
+  ~SPCL912~ => ~SPCL912B~ // Set Time Trap
+END
+
+ACTION_PHP_EACH set_snare_array AS set_resref => snare_resref BEGIN
+  // remove global "set automap note" effect from snare
+  OUTER_SET strref = "-1"
+  COPY_EXISTING ~%snare_resref%.spl~ ~override~
+    READ_LONG 0x6a ofs_fx
+    READ_SHORT 0x6e idx_fx
+    READ_SHORT 0x70 num_fx
+    FOR (idx = 0; idx < num_fx; ++idx) BEGIN
+      SET cur_fx = ofs_fx + (idx_fx + idx) * 48
+      READ_SHORT cur_fx opcode
+      PATCH_IF (opcode == 253) BEGIN  // Set automap note
+        READ_SLONG (cur_fx + 4) strref
+        LPF DELETE_EFFECT INT_VAR check_headers = 0 match_opcode = 253 END
+        SET idx = num_fx
+      END
+    END
+
+    // iwdee: fix automap note message
+    PATCH_IF (game_is_iwdee) BEGIN
+      SET strref = 36025
+      LPF ALTER_EFFECT
+        INT_VAR
+          check_globals = 0
+          match_opcode = 254  // Remove automap note
+          parameter1 = strref
+      END
+    END
+
+    // special snare: add automap note removal to ability header 2
+    PATCH_IF (~%snare_resref%~ STR_EQ ~SPCL415~) BEGIN
+      LPF ADD_SPELL_EFFECT
+        INT_VAR
+          header = 3    // ability header 2 (as one-based index)
+          opcode = 254  // Remove automap note
+          target = 2    // preset target
+          parameter1 = strref
+          timing = 9    // instant/permanent
+          insert_point = 0
+      END
+    END
+  BUT_ONLY IF_EXISTS
+
+  // add "set automap note" effect to "set snare"
+  ACTION_IF (strref >= 0) BEGIN
+    COPY_EXISTING ~%set_resref%.spl~ ~override~
+      LPF ADD_SPELL_EFFECT
+        INT_VAR
+          opcode = 253  // Set automap note
+          target = 1    // Self
+          parameter1 = strref
+          timing = 9    // instant/permanent
+      END
+    BUT_ONLY IF_EXISTS
+  END
+END

--- a/eefixpack/files/tph/bg2ee.tph
+++ b/eefixpack/files/tph/bg2ee.tph
@@ -1328,6 +1328,8 @@ INCLUDE ~eefixpack/files/tph/bg_bg2_iwd_common_spell_fixes.tph~ // spell fixes i
 
 INCLUDE ~eefixpack/files/tph/tbd_324_traps_bg2ee.tph~ // tbd, cam - game can crash if a spell-via-trap uses 318/324 vs. a spell without a name
 
+INCLUDE ~eefixpack/files/tph/a7/snares_autonotes_fix.tph~ // fixes adding an automap note to the area when a snare is set
+
 // tbd, cam
 // misindexed effects
 COPY_EXISTING ~ohbwi302.spl~ ~override~

--- a/eefixpack/files/tph/bgee.tph
+++ b/eefixpack/files/tph/bgee.tph
@@ -1413,6 +1413,8 @@ INCLUDE ~eefixpack/files/tph/bg_bg2_iwd_common_spell_fixes.tph~ // spell fixes i
 
 INCLUDE ~eefixpack/files/tph/tbd_324_traps_bgee.tph~ // tbd, cam - game can crash if a spell-via-trap uses 318/324 vs. a spell without a name
 
+INCLUDE ~eefixpack/files/tph/a7/snares_autonotes_fix.tph~ // fixes adding an automap note to the area when a snare is set
+
 // tbd, cam
 // misindexed effects (only wrong with SoD, but harmless to run on BGEE)
 COPY_EXISTING ~spin558.spl~   ~override~

--- a/eefixpack/files/tph/iwdee.tph
+++ b/eefixpack/files/tph/iwdee.tph
@@ -759,6 +759,7 @@ INCLUDE ~eefixpack/files/tph/bg_bg2_iwd_common_spell_fixes.tph~ // spell fixes i
 INCLUDE ~eefixpack/files/tph/5919_iwdee_spider_spawn.tph~ // ie-5919, cam: spider spawn only summons giant spiders, should also summon phase and sword
 INCLUDE ~eefixpack/files/tph/tbd_324_traps_iwdee.tph~ // tbd, cam - game can crash if a spell-via-trap uses 318/324 vs. a spell without a name
 
+INCLUDE ~eefixpack/files/tph/a7/snares_autonotes_fix.tph~ // fixes adding an automap note to the area when a snare is set
 
 // tbd, davidw
 // circle of bone subspell has illegal character in sig


### PR DESCRIPTION
https://www.gibberlings3.net/forums/topic/41296-the-set-special-snare-ability-of-thieves-should-add-an-automap-note-to-the-area

- Fixes setting automap notes when a snare is set
- Fixes an incorrect automap note string in IWDEE
- Adds a missing automap note removal effect to a special snare ability header